### PR TITLE
Now MAC filter deny is supported. (Only accept was supported.)

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -179,8 +179,9 @@ define_global_variables(){
     WIFI_IFACE=
     CHANNEL=default 
     WPA_VERSION=2
-    MAC_FILTER=0
+    MAC_FILTER=3  # 3 is not valid
     MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
+    MAC_FILTER_DENY=/etc/hostapd/hostapd.deny
     IEEE80211N=0
     IEEE80211AC=0
     HT_CAPAB='[HT40+]'
@@ -356,13 +357,34 @@ parse_user_options(){
                 shift
                 HIDDEN=1
                 ;;
-            --mac-filter)
-                shift
-                MAC_FILTER=1
-                ;;
+
             --mac-filter-accept)
                 shift
-                MAC_FILTER_ACCEPT="$1"
+                if [ "$MAC_FILTER_TYPE" == "deny" ]
+                then
+                    printf "ERROR: Can't use --mac-filter-accept and --mac-filter-deny together.\n"
+                    exit 1
+                fi
+                MAC_FILTER_TYPE=accept
+                MAC_FILTER=1
+                MAC_FILTER_FILE=$MAC_FILTER_ACCEPT
+                ;;
+
+            --mac-filter-deny)
+                shift
+                if [ "$MAC_FILTER_TYPE" == "accept" ]
+                then
+                    printf "ERROR: Can't use --mac-filter-accept and --mac-filter-deny together.\n"
+                    exit 1
+                fi
+                MAC_FILTER_TYPE=deny
+                MAC_FILTER=0
+                MAC_FILTER_FILE=$MAC_FILTER_DENY
+                ;;
+
+            --mac-filter-file)
+                shift
+                MAC_FILTER_FILE="$1"
                 shift
                 ;;
 
@@ -1715,8 +1737,15 @@ write_hostapd_conf() {
 
     if [[ $MAC_FILTER -eq 1 ]]; then
         cat <<- EOF >> "$CONFDIR/hostapd.conf"
-			macaddr_acl=${MAC_FILTER}
-			accept_mac_file=${MAC_FILTER_ACCEPT}
+			macaddr_acl=1
+			accept_mac_file=${MAC_FILTER_FILE}
+		EOF
+    fi
+
+    if [[ $MAC_FILTER -eq 0 ]]; then
+        cat <<- EOF >> "$CONFDIR/hostapd.conf"
+			macaddr_acl=0
+			deny_mac_file=${MAC_FILTER_FILE}
 		EOF
     fi
 


### PR DESCRIPTION
This is to support `--mac-filter-deny` after only `--mac-filter-accept` was supported.

Use:
If you want to use deny acl, use the option `--mac-filter-deny`. Similarly for accept acl, use `--mac-filter-accept`.
Obviously, you cannot use both options at the same time.
If you want to set a specific path for the mac addresses file, whether you're using deny or accept, you need to set the option `--mac-filter-file <MAC_ADDRESSES_FILE>`.