### PR TITLE
5G Support

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -89,6 +89,7 @@ Options:
                             for both Internet and AP
     --virt-name <name>      Set name of virtual interface
     -c <channel>            Channel number (default: 1)
+    --force_channel         Force the use of channel provided by -c flag
     --country <code>        Set two-letter country code for regularity
                             (example: US)
     --freq-band <GHz>       Set frequency band: 2.4 or 5 (default: 2.4)
@@ -179,6 +180,7 @@ define_global_variables(){
     HIDDEN=0 # hidden wifi hotspot
     WIFI_IFACE=
     CHANNEL=default 
+    FORCECHANNEL=0
     WPA_VERSION=2
     MAC_FILTER=0
     MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
@@ -372,6 +374,10 @@ parse_user_options(){
                 shift
                 CHANNEL="$1"
                 shift
+                ;;
+            --force_channel)
+                shift
+                FORCECHANNEL=1
                 ;;
             -w)
                 shift
@@ -1648,7 +1654,7 @@ prepare_wifi_interface() {
     
     if [[ $NO_VIRT -eq 0 ]]; then
     ## Will generate virtual wifi interface
-        if is_interface_wifi_connected ${WIFI_IFACE}; then
+        if is_interface_wifi_connected ${WIFI_IFACE} && [[ FORCECHANNEL -eq 0 ]]; then
             WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
             WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
             echo "${WIFI_IFACE} already in channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"

--- a/lnxrouter
+++ b/lnxrouter
@@ -1844,7 +1844,7 @@ write_hostapd_conf() {
 
 	if [[ $VHTSEG1CHINDEX -gt 0 ]]; then
 		cat <<- EOF >> "$CONFDIR/hostapd.conf"
-			vht_oper_centr_freq_seg1_idx=${VHTSEG0CHINDEX}
+			vht_oper_centr_freq_seg1_idx=${VHTSEG1CHINDEX}
 		EOF
 	fi
 

--- a/lnxrouter
+++ b/lnxrouter
@@ -103,14 +103,29 @@ Options:
                             (defaults to /etc/hostapd/hostapd.accept)
     --hostapd-debug <level> 1 or 2. Passes -d or -dd to hostapd
     --isolate-clients       Disable wifi communication between clients
+    --no-haveged            Do not run haveged automatically when needed
     --hs20                  Enable Hotspot 2.0 (Make sure your hostapd build supports it)
 
+    WiFi 4(802.11N) Config:
     --ieee80211n            Enable IEEE 802.11n (HT)
-    --ieee80211ac           Enable IEEE 802.11ac (VHT)
+    --use_ht                Enable High Throughput mode
     --ht_capab <HT>         HT capabilities (default: [HT40+])
+
+    WiFi 5(802.11AC) Config:
+    --ieee80211ac           Enable IEEE 802.11ac (VHT)
+    --use_vht               Enable Very High Thoughtput mode
     --vht_capab <VHT>       VHT capabilities
-    
-    --no-haveged            Do not run haveged automatically when needed
+    --vht_channel_width <index> 
+                            Index of VHT Channel Width:
+                                0 for 20MHz or 40MHz (default)
+                                1 for 80MHz
+                                2 for 160MHz
+                                3 for 80+80MHz (Non-contigous 160MHz)    
+    --seg0_center_freq_idx <channel>
+                            Channel index of Center frequency for primary segment, use with --vht_channel_width
+    --seg1_center_freq_idx <channel>
+                            Channel index of Center frequency for secondary (second 80MHz) segment, use with --vht_channel_width=3
+                            Pick above 2 values from the F0 index column from the 5GHz table in https://en.wikipedia.org/wiki/List_of_WLAN_channels#5_GHz_(802.11a/h/n/ac/ax)
 
   Instance managing:
     --daemon                Run in background
@@ -187,9 +202,14 @@ define_global_variables(){
     MAC_FILTER=0
     MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
     IEEE80211N=0
+    REQUIREHT=0
     IEEE80211AC=0
+    REQUIREVHT=0
     HT_CAPAB='[HT40+]'
     VHT_CAPAB=
+    VHTCHANNELWIDTH=0
+    VHTSEG0CHINDEX=0
+    VHTSEG1CHINDEX=0
     DRIVER=nl80211
     NO_VIRT=0 # not use virtual interface
     COUNTRY=
@@ -396,9 +416,17 @@ parse_user_options(){
                 shift
                 IEEE80211N=1
                 ;;
+            --use_ht)
+                shift
+                REQUIREHT=1
+                ;;
             --ieee80211ac)
                 shift
                 IEEE80211AC=1
+                ;;
+            --use_vht)
+                shift
+                REQUIREVHT=1
                 ;;
             --ht_capab)
                 shift
@@ -408,6 +436,21 @@ parse_user_options(){
             --vht_capab)
                 shift
                 VHT_CAPAB="$1"
+                shift
+                ;;
+            --vht_channel_width)
+                shift
+                VHTCHANNELWIDTH="$1"
+                shift
+                ;;
+            --seg0_center_freq_idx)
+                shift
+                VHTSEG0CHINDEX="$1"
+                shift
+                ;;
+            --seg1_center_freq_idx)
+                shift
+                VHTSEG1CHINDEX="$1"
                 shift
                 ;;
             --driver)
@@ -1771,13 +1814,39 @@ write_hostapd_conf() {
 		EOF
     fi
 
+    if [[ $REQUIREHT -eq 1 ]]; then
+        echo "require_ht=1" >> "$CONFDIR/hostapd.conf"
+    fi
+
     if [[ $IEEE80211AC -eq 1 ]]; then
         echo "ieee80211ac=1" >> "$CONFDIR/hostapd.conf"
+    fi
+
+    if [[ $REQUIREVHT -eq 1 ]]; then
+        echo "require_vht=1" >> "$CONFDIR/hostapd.conf"
     fi
 
     if [[ -n "$VHT_CAPAB" ]]; then
         echo "vht_capab=${VHT_CAPAB}" >> "$CONFDIR/hostapd.conf"
     fi
+
+	if [[ $VHTCHANNELWIDTH -gt 0 ]]; then
+		cat <<- EOF >> "$CONFDIR/hostapd.conf"
+			vht_oper_chwidth=${VHTCHANNELWIDTH}
+		EOF
+	fi
+
+	if [[ $VHTSEG0CHINDEX -gt 0 ]]; then
+		cat <<- EOF >> "$CONFDIR/hostapd.conf"
+			vht_oper_centr_freq_seg0_idx=${VHTSEG0CHINDEX}
+		EOF
+	fi
+
+	if [[ $VHTSEG1CHINDEX -gt 0 ]]; then
+		cat <<- EOF >> "$CONFDIR/hostapd.conf"
+			vht_oper_centr_freq_seg1_idx=${VHTSEG0CHINDEX}
+		EOF
+	fi
 
     if [[ $IEEE80211N -eq 1 ]] || [[ $IEEE80211AC -eq 1 ]]; then
         echo "wmm_enabled=1" >> "$CONFDIR/hostapd.conf"
@@ -1800,6 +1869,7 @@ write_hostapd_conf() {
     else
         echo "WARN: WiFi is not protected by password" >&2
     fi
+    echo "Config for current session is $CONFDIR/hostapd.conf" # Useful for sharing with other hostapd users.
     chmod 600 "$CONFDIR/hostapd.conf"
 }
 

--- a/lnxrouter
+++ b/lnxrouter
@@ -103,7 +103,8 @@ Options:
                             (defaults to /etc/hostapd/hostapd.accept)
     --hostapd-debug <level> 1 or 2. Passes -d or -dd to hostapd
     --isolate-clients       Disable wifi communication between clients
-    
+    --hs20                  Enable Hotspot 2.0 (Make sure your hostapd build supports it)
+
     --ieee80211n            Enable IEEE 802.11n (HT)
     --ieee80211ac           Enable IEEE 802.11ac (VHT)
     --ht_capab <HT>         HT capabilities (default: [HT40+])
@@ -180,7 +181,8 @@ define_global_variables(){
     HIDDEN=0 # hidden wifi hotspot
     WIFI_IFACE=
     CHANNEL=default 
-    FORCECHANNEL=0
+    FORCECHANNEL=0 # Forces channel provided by -c flag
+    HOTSPOT20=0 # For enabling Hotspot 2.0
     WPA_VERSION=2
     MAC_FILTER=0
     MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
@@ -378,6 +380,10 @@ parse_user_options(){
             --force_channel)
                 shift
                 FORCECHANNEL=1
+                ;;
+            --hs20)
+                shift
+                HOTSPOT20=1
                 ;;
             -w)
                 shift
@@ -1752,6 +1758,10 @@ write_hostapd_conf() {
 			macaddr_acl=${MAC_FILTER}
 			accept_mac_file=${MAC_FILTER_ACCEPT}
 		EOF
+    fi
+
+    if [[ $HOTSPOT20 -eq 1 ]]; then
+        echo "hs20=1" >> "$CONFDIR/hostapd.conf"
     fi
 
     if [[ $IEEE80211N -eq 1 ]]; then


### PR DESCRIPTION
Addresses #51 and below
## Fixes:
1. Adds Hotspot 2.0 support, which can be enabled using `--hs20` flag, subject to the user's hostapd build.
2. Adds forcing the hotspot to specified channel using `--force_channel` flag. Some WiFi cards, like my Intel AX201, can transmit to a channel while being connected to a WiFi AP in different channel.
3. Format the flag options in the help section into relevant blocks, namely WiFi 4 and WiFi 5 config.
4. Adds `--use_ht` and `--use_vht` separately to add `require_ht` and `require_vht` config option to hostapd config. They are mandatory if `--ht_capab` or `--vht_capab` are used.

## Tests:
### 1. Using the stock config:
Command:
```bash
sudo ./lnxrouter -o wlp0s20f3 -g 11 --dns 127.0.0.1 --hostname - --ap wlp0s20f3 "Plant Hotspot" -p helios123 -c 149 --country IN --ieee80211n --ieee80211ac --ht_capab "[HT40+][HT40-][SHORT-GI-40][SHORT-GI-20][RX-STBC1][DSSS_CCK-40]" --vht_capab "[MAX-MPDU-11454][VHT160][RXLDPC][SHORT-GI-80][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMEE][MU-BEAMFORMEE]" --virt-name ap0
```
Fails to turn on hotspot as the WiFi card is already connected to my Univ's 5G WiFi, which is on channel 56 and which is not supported, as seen below:
<details> <summary>Screenshot:</summary>

![Screenshot_20230928_122253](https://github.com/garywill/linux-router/assets/60005847/81bf7e26-f8ac-491d-a8f9-67b828e19c43)

</details>

### 2. Using `--force_channel` flag to overcome above:
Command:
```bash
sudo ./lnxrouter -o wlp0s20f3 -g 11 --dns 127.0.0.1 --hostname - --ap wlp0s20f3 "Plant Hotspot" -p helios123 -c 149 --country IN --ieee80211n --ieee80211ac --ht_capab "[HT40+][HT40-][SHORT-GI-40][SHORT-GI-20][RX-STBC1][DSSS_CCK-40]" --vht_capab "[MAX-MPDU-11454][VHT160][RXLDPC][SHORT-GI-80][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMEE][MU-BEAMFORMEE]" --virt-name ap0 --force_channel
```

Hostapd starts, but the channel width defaults to 40MHz. Below is a screenshot from the app `Wifiman`, showing analysis of the wifi created.
<details> <summary>Screenshot:</summary>

<img src="https://github.com/garywill/linux-router/assets/60005847/7dff9d89-0fb9-4aaf-9e8f-58a724a462b0" width=350 height=682>

</details>

### 3. Using the remaining flags for wider channel:
Command:
```bash
sudo ./lnxrouter -o wlp0s20f3 -g 11 --dns 127.0.0.1 --hostname - --ap wlp0s20f3 "Plant Hotspot" -p helios123 -c 149 --country IN --ieee80211n --ieee80211ac --ht_capab "[HT40+][HT40-][SHORT-GI-40][SHORT-GI-20][RX-STBC1][DSSS_CCK-40]" --vht_capab "[MAX-MPDU-11454][VHT160][RXLDPC][SHORT-GI-80][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMEE][MU-BEAMFORMEE]" --virt-name ap0 --force_channel --use_ht --use_vht --vht_channel_width 1 --seg0_center_freq_idx 155
```

WiFi starts with 80MHz channel as seen in the below screenshot.
<details> <summary>Screenshot:</summary>

<img src="https://github.com/garywill/linux-router/assets/60005847/28e57455-a99d-44aa-be7a-e0c2b7f172f8" height=682 width=350>

</details>

## Guide to choosing the flag arguments for 80MHz channel and above:
1. Get the ht_capab and vht_capab flags right, use the default hostapd config to build it.

<details>
<summary>Guide</summary>

  * Run `iw list | grep -i -A 15 "band 1"` to get a list of HT Capabilities. Example:
 
  ![Screenshot_20230928_131635](https://github.com/garywill/linux-router/assets/60005847/f94baa13-a428-4173-8828-09aed3c98a63)

result: [HT40+][HT40-][SHORT-GI-40][SHORT-GI-20][RX-STBC1][DSSS_CCK-40]

  * Run `iw list | grep -i -A 15 "vht capabilities"` to get a list of VHT Capabilities. Example:
  
![Screenshot_20230928_132040](https://github.com/garywill/linux-router/assets/60005847/43c1b281-b4cd-4263-abcd-a51ee741ea2e)

result: [MAX-MPDU-11454][VHT160][RXLDPC][SHORT-GI-80][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMEE][MU-BEAMFORMEE]

</details>

2. Pick a base channel and check whether your WiFi card can transmit at your desired frequency.
<details>
 <summary>Guide</summary>

  * Check the specifications for your card, make sure it supports 5GHz N or AC wireless.
 
  * Check if the AP can be initiated on the desired channel, using `iw list | grep -E "dBm\)|\(disabled\)"`

</details>

3. Decide whether you want to use 40, 80 or 160MHz channel and pick the corresponding index:
0 for 40MHz
1 for 80MHz
2 for 160MHz
3 for 80+80MHz

4. From [WLAN Channels](https://en.wikipedia.org/wiki/List_of_WLAN_channels#5_GHz_(802.11a/h/n/ac/ax)), in the 5GHz table and under the F0 Index column, pick the index under the required channel width which includes your base channel, called the segment 0 channel.
<details>
<summary> Example: </summary>
Example:

![Screenshot_20230928_140808](https://github.com/garywill/linux-router/assets/60005847/0b399ba2-c951-4229-a1d2-1ca61b4f8ab5)

I wanted 80MHz channel with base channel as 149. The channel index corresponding to those settings is **155**.
</details>

After collecting the required data,  use this format: `--use_vht --force_channel --seg0_center_freq_idx <segment 0 channel> -c <base channel> --vht_channel_width <channel width index>` 

So for my setup: `--use_vht --force_channel --seg0_center_freq_idx 155 -c 149 --vht_channel_width 1`

## Notes:
* Please don't just copy my HT and VHT Capabilities, highly suggest you make your own
* If anyone successfully makaged to create a 5G WiFi hotspot with the above flags, I encourage you to post your findings here. Every little detail can help others.
* Intel (and some others) WIFi cards randomly loose and gain the ability to transmit hotspot on certain channels, beware of that. One can patch the CRDA database and permantly alter that behaviour. YMMV.
* GaryWill plis merge this 😅