### PR TITLE
FIX #67: Remove trailing .0 from iw reported frequency

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -1700,7 +1700,7 @@ prepare_wifi_interface() {
     
         # TODO move this to check_wifi_settings() ?
         if is_interface_wifi_connected "${WIFI_IFACE}"; then
-            WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}')
+            WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}' | sed 's/\.00*//g')
             WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel "${WIFI_IFACE_FREQ}")
             
             echo "${WIFI_IFACE} already working in channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"

--- a/lnxrouter
+++ b/lnxrouter
@@ -631,7 +631,7 @@ can_transmit_to_channel() {
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         if [[ $FREQ_BAND == 2.4 ]]; then
-            CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep " 24[0-9][0-9] MHz \[${CHANNEL_NUM}\]")
+            CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep -E " 24[0-9][0-9](.0+){0,1} MHz \[${CHANNEL_NUM}\]")
         else
             CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\) MHz \[${CHANNEL_NUM}\]")
         fi

--- a/lnxrouter
+++ b/lnxrouter
@@ -631,7 +631,7 @@ can_transmit_to_channel() {
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         if [[ $FREQ_BAND == 2.4 ]]; then
-            CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep -E " 24[0-9][0-9](.0+){0,1} MHz \[${CHANNEL_NUM}\]")
+            CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep -E " 24[0-9][0-9](\.0+){0,1} MHz \[${CHANNEL_NUM}\]")
         else
             CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\) MHz \[${CHANNEL_NUM}\]")
         fi
@@ -1700,7 +1700,7 @@ prepare_wifi_interface() {
     
         # TODO move this to check_wifi_settings() ?
         if is_interface_wifi_connected "${WIFI_IFACE}"; then
-            WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}' | sed 's/\.00*//g')
+            WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}' | sed 's/\.00*$//g')
             WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel "${WIFI_IFACE_FREQ}")
             
             echo "${WIFI_IFACE} already working in channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"


### PR DESCRIPTION
This should fix #67 
The sed command removes a dot followed by any number (greater than zero) of zeros followed by the end of the line. This way frequencies now reported with a trailing .0 will also work.
Just in case it will also remove .00 and similar, but not ".", ".5" and similar because they may actually have a different meaning and thus should not be rounded away as suggested in #67 with cut but throw an error.
The more complete approach would be to use software like bc to do actual non-integer comparison but as long as there are no non-integer-frequencies used i don't think adding an additional dependency is worth it just for the sake of a theoretical future wifi frequency that will require modifications to the script anyway.