### PR TITLE
WiFi 6 Support

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -2087,8 +2087,9 @@ run_wifi_ap_processes() {
     echo 
     echo "Starting hostapd"
     
-    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
-        $COMPLAIN_CMD hostapd
+    if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
+        echo "Setting hostapd to AppArmor complain mode..."
+        "$COMPLAIN_CMD" hostapd
     fi
     
     # hostapd '-P' works only when use '-B' (run in background)
@@ -2108,10 +2109,9 @@ start_dnsmasq() {
     echo 
     echo "Starting dnsmasq"
     
-    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
-        # openSUSE's apparmor does not allow dnsmasq to read files.
-        # remove restriction.
-        $COMPLAIN_CMD dnsmasq
+    if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
+        echo "Setting dnsmasq to AppArmor complain mode..."
+        "$COMPLAIN_CMD" dnsmasq
     fi
     
     # Using '-d'(no daemon) dnsmasq will not turn into 'nobody'

--- a/lnxrouter
+++ b/lnxrouter
@@ -2051,7 +2051,7 @@ write_hostapd_conf() {
 		EOF
 	fi
 
-    if [[ $IEEE80211N -eq 1 ]] || [[ $IEEE80211AC -eq 1 ]]; then
+    if [[ $IEEE80211N -eq 1 ]] || [[ $IEEE80211AC -eq 1 ]] || [[ $IEEE80211AX -eq 1 ]]; then
         echo "wmm_enabled=1" >> "$CONFDIR/hostapd.conf"
     fi
 

--- a/lnxrouter
+++ b/lnxrouter
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.7.6b
+VERSION=0.7.6
 PROGNAME="$(basename "$0")"
 
 export LC_ALL=C

--- a/lnxrouter
+++ b/lnxrouter
@@ -676,7 +676,7 @@ can_transmit_to_channel() {
     fi
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then
-        CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep -E " ${CHANNEL_FREQ_FILTER}[0-9]+(\.[0-9]+){0,1} MHz \[${CHANNEL_NUM}\]")
+        CHANNEL_INFO=$(get_adapter_info "${IFACE}" | grep -E " ${CHANNEL_FREQ_FILTER}[0-9]{2}(\.[0-9]+){0,1} MHz \[${CHANNEL_NUM}\]")
         [[ -z "${CHANNEL_INFO}" ]] && return 1
         [[ "${CHANNEL_INFO}" == *no\ IR* ]] && return 2
         [[ "${CHANNEL_INFO}" == *disabled* ]] && return 3

--- a/lnxrouter
+++ b/lnxrouter
@@ -670,9 +670,9 @@ can_transmit_to_channel() {
     if [[ $FREQ_BAND == "2.4" ]]; then
         CHANNEL_FREQ_FILTER="(24)"
     elif [[ $FREQ_BAND -eq 5 ]]; then
-        CHANNEL_FREQ_FILTER="(5[0-8])"
+        CHANNEL_FREQ_FILTER="(5[1-8])"
     elif [[ $FREQ_BAND -eq 6 ]]; then
-        CHANNEL_FREQ_FILTER="((59)|(6[0-9])|(70))"
+        CHANNEL_FREQ_FILTER="((59)|(6[0-9])|(7[0-1]))"
     fi
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then

--- a/lnxrouter
+++ b/lnxrouter
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.8.0-unstable2
+VERSION=0.8.0-unstable1
 PROGNAME="$(basename "$0")"
 
 export LC_ALL=C
@@ -33,17 +33,17 @@ Options:
                             queries to other interfaces)
     -n                      Do not provide Internet
     --ban-priv              Disallow clients to access my private network
-
+    
     -g <ip>                 This host's IPv4 address in subnet (mask is /24)
                             (example: '192.168.5.1' or '5' shortly)
     -6                      Enable IPv6 (NAT)
     --no4                   Disable IPv4 Internet (not forwarding IPv4).
                             Usually used with '-6'
-
-    --p6 <prefix>           Set IPv6 LAN address prefix (length 64)
-                            (example: 'fd00:0:0:5::' or '5' shortly)
+                            
+    --p6 <prefix>           Set IPv6 LAN address prefix (length 64) 
+                            (example: 'fd00:0:0:5::' or '5' shortly) 
                             Using this enables '-6'
-
+                            
     --dns <ip>|<port>|<ip:port>
                             DNS server's upstream DNS.
                             Use ',' to seperate multiple servers
@@ -51,37 +51,37 @@ Options:
                             (Note IPv6 addresses need '[]' around)
     --no-dns                Do not serve DNS
     --no-dnsmasq            Disable dnsmasq server (DHCP, DNS, RA)
-    --catch-dns             Transparent DNS proxy, redirect packets(TCP/UDP)
+    --catch-dns             Transparent DNS proxy, redirect packets(TCP/UDP) 
                             whose destination port is 53 to this host
     --log-dns               Show DNS query log (dnsmasq)
     --dhcp-dns <IP1[,IP2]>|no
                             Set IPv4 DNS offered by DHCP (default: this host).
     --dhcp-dns6 <IP1[,IP2]>|no
-                            Set IPv6 DNS offered by DHCP (RA)
+                            Set IPv6 DNS offered by DHCP (RA) 
                             (default: this host)
                             (Note IPv6 addresses need '[]' around)
-                            Using both above two will enable '--no-dns'
+                            Using both above two will enable '--no-dns' 
     --hostname <name>       DNS server associate this name with this host.
                             Use '-' to read name from /etc/hostname
     -d                      DNS server will take into account /etc/hosts
-    -e <hosts_file>         DNS server will take into account additional
+    -e <hosts_file>         DNS server will take into account additional 
                             hosts file
     --dns-nocache           DNS server no cache
-
+    
     --mac <MAC>             Set MAC address
     --random-mac            Use random MAC address
-
+ 
     --tp <port>             Transparent proxy,
                             redirect non-LAN TCP and UDP(not tested) traffic to
                             port. (usually used with '--dns')
-
+    
   WiFi hotspot options:
     --ap <wifi interface> <SSID>
                             Create WiFi access point
-    -p, --password <password>
+    -p, --password <password>   
                             WiFi password
     --qr                    Show WiFi QR code in terminal (need qrencode)
-
+    
     --hidden                Hide access point (not broadcast SSID)
     --no-virt               Do not create virtual interface
                             Using this you can't use same wlan interface
@@ -113,44 +113,44 @@ Options:
     --wifi5                 Enable IEEE 802.11ac (VHT)
     --req-vht               Require station VHT (Very High Thoughtput) mode
     --vht-capab <VHT caps>  VHT capabilities
-
+    
     --vht-ch-width <index>  Index of VHT channel width:
                                 0 for 20MHz or 40MHz (default)
                                 1 for 80MHz
                                 2 for 160MHz
-                                3 for 80+80MHz (Non-contigous 160MHz)
-    --vht-seg0-ch <channel> Channel index of VHT center frequency for primary
+                                3 for 80+80MHz (Non-contigous 160MHz)    
+    --vht-seg0-ch <channel> Channel index of VHT center frequency for primary 
                             segment. Use with '--vht-ch-width'
     --vht-seg1-ch <channel> Channel index of VHT center frequency for secondary
                             (second 80MHz) segment. Use with '--vht-ch-width 3'
-
+   
     WiFi 6 (802.11ax) configs:
     --wifi6                 Enable IEEE 802.11ax (HE)
     --req-he                Require station HE (High Efficiency) mode
-
+    
     --he-ch-width <index>   Index of HE channel width:
                                 0 for 20MHz or 40MHz (default)
                                 1 for 80MHz
                                 2 for 160MHz
-                                3 for 80+80MHz (Non-contigous 160MHz)
+                                3 for 80+80MHz (Non-contigous 160MHz)    
     --he-seg0-ch <channel>  Channel index of HE center frequency for primary
                             segment. Use with '--he-ch-width'
     --he-seg1-ch <channel>  Channel index of HE center frequency for secondary
                             (second 80MHz) segment. Use with '--he-ch-width 3'
-
+ 
   Instance managing:
     --daemon                Run in background
     --keep-confdir          Don't delete the temporary config dir after exit
 
     -l, --list-running      Show running instances
-    --lc, --list-clients <id|interface>
+    --lc, --list-clients <id|interface>     
                             List clients of an instance. Or list neighbors of
                             an interface, even if it isn't handled by us.
                             (passive mode)
     --stop <id>             Stop a running instance
         For <id> you can use PID or subnet interface name.
         You can get them with '--list-running'
-
+                
 Examples:
     $PROGNAME -i eth1
     $PROGNAME --ap wlan0 MyAccessPoint -p MyPassPhrase
@@ -185,26 +185,26 @@ define_global_variables(){
     DNS_NOCACHE=
     CONN_IFACE=    # which interface user choose to use to create network
     INTERNET_IFACE= # which interface to get Internet from
-    THISHOSTNAME=   # this host's name the DNS tells clients
+    THISHOSTNAME=   # this host's name the DNS tells clients 
     TP_PORT=  # transparent proxy port
     DNS=  # upstream DNS
     MAC_USE_RANDOM=0
     NEW_MACADDR=
     DAEMONIZE=0
-
+    
     # script variables
     SUBNET_IFACE=  # which interface to create network
-    SHARE_METHOD=nat
+    SHARE_METHOD=nat 
     OLD_MACADDR=
     SUBNET_NET4=
     SUBNET_NET6=
-
+    
 
     ##### wifi hotspot
     # user options
     HIDDEN=0 # hidden wifi hotspot
     WIFI_IFACE=
-    CHANNEL=default
+    CHANNEL=default 
     HOTSPOT20=0 # For enabling Hotspot 2.0
     WPA_VERSION=2
     MAC_FILTER=0
@@ -232,7 +232,7 @@ define_global_variables(){
     USE_PSK=0
     ISOLATE_CLIENTS=0
     QR=0 # show wifi qr
-
+    
     # script variables
     PHY=
     VWIFI_IFACE=  # virtual wifi interface name, if created
@@ -240,7 +240,7 @@ define_global_variables(){
     AP_IFACE=     # can be VWIFI_IFACE or WIFI_IFACE
     USE_IWCONFIG=0  # some device can't use iw
     #######
-
+    
     #-- to deal with info of a running instance. then will exit
     LIST_RUNNING=0
     STOP_ID=
@@ -291,8 +291,8 @@ parse_user_options(){
                 SHARE_METHOD=redsocks
                 shift
                 ;;
-
-
+                
+                
             -g)
                 shift
                 GATEWAY4="$1"
@@ -321,7 +321,7 @@ parse_user_options(){
                 shift
                 MAC_USE_RANDOM=1
                 ;;
-
+                
             --dns)
                 shift
                 DNS="$1"
@@ -348,7 +348,7 @@ parse_user_options(){
             --catch-dns)
                 shift
                 CATCH_DNS=1
-                ;;
+                ;;    
             --log-dns)
                 shift
                 SHOW_DNS_QUERY=1
@@ -371,12 +371,12 @@ parse_user_options(){
                 shift
                 DNS_NOCACHE=1
                 ;;
-
+            
             --isolate-clients)
                 shift
                 ISOLATE_CLIENTS=1
                 ;;
-
+                
             --ap)
                 shift
                 WIFI_IFACE="$1"
@@ -393,8 +393,8 @@ parse_user_options(){
                 shift
                 QR=1
                 ;;
-
-
+                
+                
             --hidden)
                 shift
                 HIDDEN=1
@@ -580,7 +580,7 @@ sep_ip_port() {
     local PORT
     local INPUT
     INPUT="$1"
-    if (echo "$INPUT" | grep '\.' >/dev/null 2>&1) ;then
+    if (echo "$INPUT" | grep '\.' >/dev/null 2>&1) ;then  
         if (echo "$INPUT" | grep ':' >/dev/null 2>&1) ;then
             # ipv4 + port
             IP="$(echo "$INPUT" | cut -d: -f1)"
@@ -589,7 +589,7 @@ sep_ip_port() {
             # ipv4
             IP="$INPUT"
         fi
-    elif (echo "$INPUT" | grep '\]' >/dev/null 2>&1) ;then
+    elif (echo "$INPUT" | grep '\]' >/dev/null 2>&1) ;then 
         if (echo "$INPUT" | grep '\]\:' >/dev/null 2>&1) ;then
             # ipv6 + port
             IP="$(echo "$INPUT" | cut -d']' -f1 | cut -d'[' -f2)"
@@ -598,7 +598,7 @@ sep_ip_port() {
             # ipv6
             IP="$(echo "$INPUT" | cut -d']' -f1 | cut -d'[' -f2)"
         fi
-    else
+    else 
         # port
         IP='127.0.0.1'
         PORT="$INPUT"
@@ -745,35 +745,35 @@ get_interface_mac() {
 
 show_interface_pci_info() {  # pci id / model / virtual
     is_interface "$1" || return
-
+    
     local device_path
     local bus_id=""
     local device_type_and_bus_id="unknown"
     local driver=""
     local device_fullname=""
-
+    
     device_path="$(readlink -f /sys/class/net/$1)"
-
+    
     if [[ "$device_path" == "/sys/devices/pci"* ]]; then
         local pci_path
 
         pci_path=$device_path/../..
-
+        
         if [[ -d "$pci_path/driver" ]] ; then
             driver=$(readlink -f "$pci_path/driver" | sed 's/\//\n/g' | tail -n 1)
         fi
-
+        
         bus_id="$(echo "$device_path" | sed 's/\//\n/g' | tail -n 3 |sed -n 1p)"
         device_type_and_bus_id="PCI: $bus_id"
-
+        
         if which lspci >/dev/null 2>&1 ; then
             device_fullname="$( lspci -D -nn -s "$bus_id" | awk '{$1="" ; print $0}' )"
         fi
-
+        
     elif [[ "$device_path" == *"/virtual/"* ]]; then
         device_type_and_bus_id="virtual interface"
     fi
-
+    
     echo "$device_type_and_bus_id"
     [[ -n "$driver" ]] && echo "System-already-loaded driver: $driver"
     [[ -n "$device_fullname" ]] && echo "$device_fullname"
@@ -820,7 +820,7 @@ get_new_macaddr_according_to_existing() {
 }
 
 generate_random_mac() {
-    local r1 r2 r3 r4 r5 r6
+    local r1 r2 r3 r4 r5 r6 
     local RAND_MAC
     while :; do
         r1=$( printf "%02x" $(($RANDOM%256/4*4)) )
@@ -905,7 +905,7 @@ pid_watchdog() {
     local ERR_MSG="$3"
     local ST
     while true
-    do
+    do 
         if [[ -e "/proc/$PID" ]]; then
             ST="$(cat "/proc/$PID/status" | grep "^State:" | awk '{print $2}')"
             if [[ "$ST" != 'Z' ]]; then
@@ -915,18 +915,18 @@ pid_watchdog() {
         fi
         die "$ERR_MSG"
     done
-
+    
 }
 #========
 get_pid_by_dbus_name() {
     local DBUS_NAME="$1"
     local pid  r
-
+    
     which dbus-send >/dev/null 2>&1 || return 1
-
+    
     pid="$( dbus-send --system --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.GetConnectionUnixProcessID string:$DBUS_NAME  2>/dev/null | grep "   uint32 " | awk '{print $2}' )"
     r=$?
-
+    
     echo "$pid"
     return $r
 }
@@ -940,15 +940,15 @@ is_same_netns() {
 # only support NetworkManager >= 0.9.9
 is_nm_running() {
     NM_PID="$(get_pid_by_dbus_name "org.freedesktop.NetworkManager")"
-
+    
     [[ ! -n "$NM_PID" ]] && return 1 # not running
-
+    
     if (which nmcli >/dev/null 2>&1 ) && (nmcli -t -f RUNNING g 2>&1 | grep -E '^running$' >/dev/null 2>&1 ) ; then
         if is_same_netns "$NM_PID"; then
             return 0
         fi
     fi
-
+    
     NM_PID= # cancel value if treat as not running
     return 1  # not running
 }
@@ -989,9 +989,9 @@ nm_restore_manage() {
 #-------
 is_firewalld_running() {
     FIREWALLD_PID="$(get_pid_by_dbus_name "org.fedoraproject.FirewallD1")"
-
+    
     [[ ! -n "$FIREWALLD_PID" ]] && return 1 # not running
-
+    
     if (which firewall-cmd >/dev/null 2>&1 ) && [[ "$(firewall-cmd --state 2>&1)" == "running" ]] ; then
         if is_same_netns "$FIREWALLD_PID"; then
             echo "firewalld is running ($(firewall-cmd --version))"
@@ -1022,7 +1022,7 @@ CUSTOM_CHAINS_4_filter=
 CUSTOM_CHAINS_4_nat=
 CUSTOM_CHAINS_6_filter=
 CUSTOM_CHAINS_6_nat=
-iptb()
+iptb() 
 {
     local FoS=$1 # 4 | 6
     shift
@@ -1034,26 +1034,26 @@ iptb()
     shift
     local CH=$1 # chain
     shift
-
+    
     [[ "$IPV6" -ne 1 && "$FoS" == "6" ]] && return
-
+    
     local CMD_HEAD=""
     local MOUTH=""
     local NECK=""
     local HAND_UN_NC=0
     local TAIL=""
-
+    
     local FULL=""
     local ADD_TO_UNDO=1
-
+    
     local arr_name  w
-
+    
     for arr_name in CUSTOM_CHAINS_4_filter CUSTOM_CHAINS_4_nat CUSTOM_CHAINS_6_filter CUSTOM_CHAINS_6_nat
     do
         local arr_content
         eval arr_content=\"\${$arr_name}\"
         #echo $arr_content
-
+        
         for w in  $arr_content
         do
             if [[ "$arr_name" =~ "$FoS" && "$arr_name" =~ "$T" && "$w" == "$CH" ]]; then
@@ -1061,37 +1061,37 @@ iptb()
             fi
         done
     done
-
+    
 
     [[ "$FoS" == "4" ]] && CMD_HEAD="iptables -w "
     [[ "$FoS" == "6" ]] && CMD_HEAD="ip6tables -w "
-
+    
     [[ "$Vis" == 'v' ]] && MOUTH="-v"
-
+    
     NECK="-t ${T}"
-
+    
     if [[ "$ACT" == "N" ]]; then
         eval CUSTOM_CHAINS_${FoS}_${T}=\"\${CUSTOM_CHAINS_${FoS}_${T}} ${CH}\"
         HAND_UN_NC=1
     fi
-
-
-
+    
+    
+    
     [[ ! "$NETFILTER_XT_MATCH_COMMENT" == "0" ]] && TAIL="-m comment --comment lrt${$}${SUBNET_IFACE}"
-
+    
     if [[ "$ADD_TO_UNDO" -eq 1 ]]; then
         if [[ "$ACT" == "I" || "$ACT" == "A" ]]; then
-            echo "$CMD_HEAD $NECK -D ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables.sh
+            echo "$CMD_HEAD $NECK -D ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables.sh 
         fi
-
+        
         if [[ "$HAND_UN_NC" -eq 1 ]]; then
             echo "$CMD_HEAD $NECK -F ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables_2.sh
             echo "$CMD_HEAD $NECK -X ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables_2.sh
         fi
     fi
-
-
-
+    
+ 
+    
 
     FULL="$CMD_HEAD $MOUTH $NECK -${ACT} ${CH} $@ $TAIL"
     #echo $FULL
@@ -1109,40 +1109,40 @@ disable_unwanted_forwarding() {
                 ! -i "$INTERNET_IFACE"    -o "$SUBNET_IFACE" \
                 -j REJECT || die
         fi
-
+        
         if [[ "$SHARE_METHOD" == 'redsocks' || "$SHARE_METHOD" == 'none' \
             || ( "$iv" -eq "4" && "$NO4" -eq 1  ) ]];then
             iptb "$iv" n filter I FORWARD  -i "$SUBNET_IFACE"  -j REJECT || die
             iptb "$iv" n filter I FORWARD  -o "$SUBNET_IFACE"  -j REJECT || die
         fi
     done
-
+        
 }
 start_nat() {
     local SUBNET_NET
-
+    
     local iv
 
     echo
     echo "iptables: NAT "
-
+    
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" && ! $NO4 -eq 0 ]] && continue
-
+        
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
-
+        
         if [[ -n "$INTERNET_IFACE" ]]; then # only one Internet interface
             # masquerade subnet -> internet
             iptb "$iv" v nat I POSTROUTING -s "$SUBNET_NET"  ! -d "$SUBNET_NET" \
                 -o "$INTERNET_IFACE" \
                 -j MASQUERADE || die
-
+                
             # forward subnet -> internet
             iptb "$iv" v filter I FORWARD  -i "$SUBNET_IFACE"  -s "$SUBNET_NET" \
                 -o $INTERNET_IFACE \
                 -j ACCEPT || die
-
+            
             # forward any -> subnet
             iptb "$iv" v filter I FORWARD  -o "$SUBNET_IFACE"  -d "$SUBNET_NET"  \
                 -i "$INTERNET_IFACE" \
@@ -1152,32 +1152,32 @@ start_nat() {
             iptb "$iv" v nat I POSTROUTING -s "$SUBNET_NET"  ! -d "$SUBNET_NET" \
                 ! -o "$SUBNET_IFACE"  \
                 -j MASQUERADE || die
-
+                
             # forward subnet -> any
             iptb "$iv" v filter I FORWARD  -i "$SUBNET_IFACE"  -s "$SUBNET_NET"  \
                 -j ACCEPT || die
-
+                
             # forward any -> subnet
             iptb "$iv" v filter I FORWARD  -o "$SUBNET_IFACE"  -d "$SUBNET_NET" \
                 -j ACCEPT || die
         fi
-    done
+    done 
 }
 
 start_ban_lan() {
     local arr_nets_to_protect
     local ICMP_NAME
     local iv  s
-
+    
     echo
     echo "iptables: Disallow clients to access LAN"
-
+    
     for iv in "${IP_VERs[@]}"; do
         # ban forwarding for subnet
         iptb "$iv" n filter N lrt${$}${SUBNET_IFACE}-BLF || die
         # TODO: allow '--dhcp-dns(6)' address port 53, which can be something needed, e.g. a VPN's internal private IP
         if [[ "$iv" -eq "4" ]]; then
-            arr_nets_to_protect=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255")
+            arr_nets_to_protect=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255") 
             ICMP_NAME="icmp"
         elif [[ "$iv" -eq "6" ]]; then
             arr_nets_to_protect=("fc00::/7" "fe80::/10" "ff00::/8" "::1" "::/128" "::ffff:0:0/96" "::ffff:0:0:0/96")
@@ -1187,7 +1187,7 @@ start_ban_lan() {
             iptb "$iv" v filter I lrt${$}${SUBNET_IFACE}-BLF -d "$s" -j REJECT || die
         done
         iptb "$iv" n filter I FORWARD -i ${SUBNET_IFACE} -j lrt${$}${SUBNET_IFACE}-BLF || die
-
+        
         # ban input from subnet
         iptb "$iv" n filter N lrt${$}${SUBNET_IFACE}-BLI || die
         iptb "$iv" v filter I lrt${$}${SUBNET_IFACE}-BLI -i ${SUBNET_IFACE} ! -p "$ICMP_NAME" -j REJECT || die # ipv6 need icmp to function. TODO: maybe we can block some unneeded icmp to improve security
@@ -1202,14 +1202,14 @@ allow_dns_port() {
     local PROTs
     local iv  pt
 
-
+    
     echo
     echo "iptables: allow DNS"
-
+    
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" ]] && GATEWAY="$GATEWAY4"
         [[ "$iv" -eq "6" ]] && GATEWAY="$GATEWAY6"
-
+        
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
 
@@ -1218,7 +1218,7 @@ allow_dns_port() {
         for pt in "${PROTs[@]}"; do
             iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -d "$GATEWAY" -p "$pt" -m "$pt" --dport 53 -j ACCEPT || die
         done
-    done
+    done 
 }
 
 
@@ -1229,11 +1229,11 @@ start_catch_dns() {
 
     echo
     echo "iptables: redirect DNS queries to this host"
-
+    
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" ]] && GATEWAY="$GATEWAY4"
         [[ "$iv" -eq "6" ]] && GATEWAY="$GATEWAY6"
-
+   
         PROTs=("tcp" "udp")
         for pt in "${PROTs[@]}"; do
             iptb "$iv" v nat I PREROUTING -i "$SUBNET_IFACE" ! -d "$GATEWAY" -p "$pt" -m "$pt" --dport 53 -j REDIRECT --to-ports 53 || die
@@ -1243,9 +1243,9 @@ start_catch_dns() {
 
 
 allow_dhcp() {
-    echo
+    echo 
     echo "iptables: allow dhcp"
-
+    
     iptb 4 v filter I INPUT -i ${SUBNET_IFACE} -p udp -m udp --dport 67 -j ACCEPT || die
     iptb 6 v filter I INPUT -i ${SUBNET_IFACE} -p udp -m udp --dport 547 -j ACCEPT || die
 }
@@ -1255,25 +1255,25 @@ start_redsocks() {
     local SUBNET_NET
     local arr_nets_to_ignore
     local s iv
-
+    
     echo
     echo "iptables: transparent proxy non-LAN TCP and UDP(not tested) traffic to port ${TP_PORT}"
-
+    
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" && ! $NO4 -eq 0 ]] && continue
-
+        
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
-
-
+            
+            
         iptb "$iv" n nat N lrt${$}${SUBNET_IFACE}-TP || die
-
+        
         if [[ "$iv" -eq "4" ]]; then
             arr_nets_to_ignore=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255")
         elif [[ "$iv" -eq "6" ]];then
             arr_nets_to_ignore=("fc00::/7" "fe80::/10" "ff00::/8" "::1" "::")
         fi
-
+        
         for s in "${arr_nets_to_ignore[@]}"; do
             iptb "$iv" n nat A lrt${$}${SUBNET_IFACE}-TP -d "$s" -j RETURN || die
         done
@@ -1283,7 +1283,7 @@ start_redsocks() {
 
         iptb "$iv" v nat I PREROUTING -i "$SUBNET_IFACE" -s "$SUBNET_NET" -j lrt${$}${SUBNET_IFACE}-TP || die
 
-
+        
         iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -p tcp -m tcp --dport ${TP_PORT}  -j ACCEPT || die
         iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -p udp -m udp --dport ${TP_PORT}  -j ACCEPT || die
     done
@@ -1297,7 +1297,7 @@ backup_ipv6_bits() {
         "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/use_tempaddr"  \
         "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/addr_gen_mode" \
             "$CONFDIR/sys_6_conf_iface/" || die "Failed backing up interface ipv6 bits"
-
+            
     if [[ "$SHARE_METHOD" == 'redsocks' ]] ; then
         cp "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/forwarding" \
             "$CONFDIR/sys_6_conf_iface/" || die "Failed backking up interface ipv6 bits"
@@ -1322,45 +1322,45 @@ restore_ipv6_bits() {
 set_interface_mac() {
     local INTERFACE
     local MAC
-
+    
     INTERFACE=$1
     MAC=$2
-
-    ip link set dev "${INTERFACE}" address "${MAC}"
+    
+    ip link set dev "${INTERFACE}" address "${MAC}" 
 }
 
 backup_interface_status() {
     # virtual wifi interface will be destroyed, so no need to save status
-
+    
     # backup interface up or down status
     (ip link show "${SUBNET_IFACE}" |grep -q "state UP") && SUBNET_IFACE_ORIGINAL_UP_STATUS=1
-
-    # save interface old mac
-    #if [[ -n "$NEW_MACADDR" ]]; then
+    
+    # save interface old mac 
+    #if [[ -n "$NEW_MACADDR" ]]; then 
         OLD_MACADDR=$(get_interface_mac "$SUBNET_IFACE")
         #echo "Saved ${SUBNET_IFACE} old MAC address ${OLD_MACADDR} into RAM"
     #fi
-
+    
     backup_ipv6_bits
-
+    
     # TODO : ? backup ip and others???
-
+    
     # nm managing status is saved when nm_set_unmanaged()
 }
 restore_interface_status() {
     # virtual wifi interface will be destroyed, so no need to restore status
     # don't use [[ $VWIFI_IFACE ]] to judge, if creating virtual wifi failed, VWIFI_IFACE is empty
     [[ "$WIFI_IFACE" && "$NO_VIRT" -eq 0 ]] && return
-
+    
     restore_ipv6_bits
 
     if [[ -n "$OLD_MACADDR" && "$(get_interface_mac "$SUBNET_IFACE")" != "$OLD_MACADDR" ]] ; then
         echo "Restoring ${SUBNET_IFACE} to old MAC address ${OLD_MACADDR} ..."
         set_interface_mac "${SUBNET_IFACE}" "${OLD_MACADDR}" || echo "Failed restoring ${SUBNET_IFACE} to old MAC address ${OLD_MACADDR}" >&2
     fi
-
+    
     nm_restore_manage
-
+    
     [[ $SUBNET_IFACE_ORIGINAL_UP_STATUS -eq 1 ]] && ip link set up dev "${SUBNET_IFACE}" && echo "Restore ${SUBNET_IFACE} to link up"
 }
 #---------------------------------------
@@ -1373,7 +1373,7 @@ kill_processes() { # for this instance
         # a value in $x. so we need to check if the value is a file
         if [[ -f $x ]] &&  sleep 0.3  && [[ -f $x ]]; then
             pid=$(cat "$x")
-            pn=$( ps -p "$pid" -o comm= )
+            pn=$( ps -p "$pid" -o comm= ) 
             #echo "Killing $pid $pn ... "
             pkill -P "$pid"
             kill "$pid" 2>/dev/null && ( echo "Killed $(basename "$x") $pid $pn" && rm "$x" ) || echo "Failed to kill $(basename "$x") $pid $pn, it may have exited"
@@ -1385,27 +1385,27 @@ _cleanup() {
     local x
 
     ip addr flush "${SUBNET_IFACE}"
-
+    
     [[ ! "$KEEP_CONFDIR" -eq 1 ]] && rm -rf "$CONFDIR"
-
+    
     ip link set down dev "${SUBNET_IFACE}"
-
+    
     firewalld_del_tmpzone
-
+    
     if [[ $VWIFI_IFACE ]]; then # the subnet interface (virtual wifi interface) will be removed
         iw dev "${VWIFI_IFACE}" del
         dealloc_vface_name "$VWIFI_IFACE"
     fi
-
+    
     restore_interface_status
-
+    
     if ! has_running_instance; then
         echo "Exiting: This is the only running instance"
         # kill common processes
         for x in $COMMON_CONFDIR/*.pid; do
             [[ -f $x ]] && kill -9 $(cat "$x") && rm "$x"
         done
-
+        
         rm -d "$COMMON_CONFDIR/vfaces"
         rm -d "$COMMON_CONFDIR"
         rm -d "$TMPDIR"
@@ -1416,7 +1416,7 @@ _cleanup() {
 
 clean_iptables() {
     [[ -f $CONFDIR/undo_iptables.sh ]] && bash $CONFDIR/undo_iptables.sh
-
+    
     [[ -f $CONFDIR/undo_iptables_2.sh ]] && bash $CONFDIR/undo_iptables_2.sh
 }
 
@@ -1430,11 +1430,11 @@ cleanup() {
     echo "Undoing iptables changes .."
     clean_iptables > /dev/null
     _cleanup 2> /dev/null
-
+    
     #pgid=$(ps opgid= $$ |awk '{print $1}' )
     #echo "Killing PGID $pgid ..."
     #kill -15 -$pgid
-    #sleep 1
+    #sleep 1 
     echo "Cleaning up done"
     #kill -9 -$pgid
 }
@@ -1526,7 +1526,7 @@ print_clients_from_leases() {  # MAC|IP|HOST|lease
     local FILEC
     local line
     local LEASEstr LEASEstamp
-
+    
     FILEC="$(cat "$LEASE_FILE" | grep -v -E "^duid\b" | sed -r '/^\s*$/d' )"
 
     # TODO: duid is somewhat related to ipv6. I don't know about it. Not sure excluding it miss some info or not
@@ -1537,31 +1537,31 @@ print_clients_from_leases() {  # MAC|IP|HOST|lease
         MAC="$(echo "$line" | awk '{print $2}')"
         IP="$(echo "$line" | awk '{print $3}'  | sed 's/\[//g' | sed 's/\]//g')"
         HOST="$(echo "$line" | awk '{print $4}' | sed 's/*/?/g' | sed 's/|/_/g' | sed 's/ /_/g' )"
-
+        
         if [[ -n "$MAC" ]]; then
             LEASEstr="$(date -d @${LEASEstamp} +%m-%d_%X)"
-
+            
             echo "$MAC|$IP|$HOST|lease_$LEASEstr"
         fi
     done
-
+    
 }
-print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS
+print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS 
     local IFACE=$1
-
+    
     local line
-
+    
     ip n | grep -E "\bdev $IFACE\b" | sed 's/ /|/g' | while read -r line
     do
         local MAC IP STATUS
-
+        
         IP="$(echo "$line" | awk -F'|' '{print $1}')"
-
+        
         if [[ "$(echo "$line" | awk -F'|' '{print $4}')" == "lladdr" ]]; then # has mac
             # if has mac, $4="lladdr" and $5=macaddress and $6+=status
             MAC="$(echo "$line" | awk -F'|' '{print $5}')"
             STATUS="$(echo "$line" | awk -F'|' '$1="";$2="";$3="";$4="";$5="";{print}' | awk '{$1=$1;print}'| sed 's/ /,/g')"
-        else # no mac
+        else # no mac 
             # if no mac, $4="" and $5+=status
             MAC="?"
             STATUS="$(echo "$line" | awk -F'|' '$1="";$2="";$3="";$4="";{print}' | awk '{$1=$1;print}' | sed 's/ /,/g')"
@@ -1571,7 +1571,7 @@ print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS
         fi
     done
 }
-print_interface_neighbors_via_iw() {  # MAC|_|_|signal
+print_interface_neighbors_via_iw() {  # MAC|_|_|signal  
     local IFACE=$1
     local MAC SIGNAL
     iw dev "$IFACE" station dump | awk '($1 ~ /Station$/) {print $2}' | while read -r MAC
@@ -1586,14 +1586,14 @@ print_interface_neighbors_via_iw() {  # MAC|_|_|signal
 list_clients() { # passive mode. (use 'arp-scan' or 'netdiscover' if want active mode)
     local IFACE pid
     local CONFDIR
-
+    
     local output=""
     # If number (PID) is given, get the associated wifi iface
     if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
         pid="$1"
         IFACE=$(get_subn_iface_from_pid "$pid")
         if [[ -z "$IFACE" ]] ; then
-            echo "'$pid' is not the pid of a running $PROGNAME instance." >&2
+            echo "'$pid' is not the pid of a running $PROGNAME instance." >&2 
             exit 1
         fi
     else # non-number given
@@ -1612,14 +1612,14 @@ list_clients() { # passive mode. (use 'arp-scan' or 'netdiscover' if want active
     fi
     output="$(echo "$output" ; print_interface_neighbors_via_iw "$IFACE") "
     output="$(echo "$output" ; print_interface_neighbors_via_iproute "$IFACE")"
-
+    
     output="$(echo "$output" | sort -k 1 -k 2 -t '|' | uniq | sed -r '/^\s*$/d')"
 
     echo "$IFACE ($(get_interface_mac "$IFACE")) neighbors:"
-
+    
     local fmt="%-19s%-41s%-20s%s" # string length: MAC 17, ipv4 15, ipv6 39, hostname ?
     printf "$fmt\n"  "MAC" "IP" "HOSTNAME" "INFO"
-
+    
     local line
     echo "$output"| while read -r line
     do
@@ -1732,14 +1732,14 @@ check_wifi_settings() {
         echo "WARN: Can't use 'iw' to operate interfce '$WIFI_IFACE', trying 'iwconfig' (not as good as 'iw') ..." >&2
         USE_IWCONFIG=1
     fi
-
+    
     if [[ $USE_IWCONFIG -eq 1 ]]; then
         if ! (which iwconfig > /dev/null 2>&1 && iwconfig "$WIFI_IFACE" > /dev/null 2>&1); then
             echo "ERROR: Can't use 'iwconfig' to operate interfce '$WIFI_IFACE'" >&2
             exit 1
         fi
     fi
-
+    
     if [[ $FREQ_BAND != 2.4 && $FREQ_BAND != 5 ]]; then
         echo "ERROR: Invalid frequency band" >&2
         exit 1
@@ -1778,7 +1778,7 @@ check_wifi_settings() {
             DRIVER=rtl871xdrv
         fi
     fi
-
+    
     if [[ ${#SSID} -lt 1 || ${#SSID} -gt 32 ]]; then
         echo "ERROR: Invalid SSID length ${#SSID} (expected 1..32)" >&2
         exit 1
@@ -1854,32 +1854,32 @@ decide_ip_addresses() {
     if [[ $IPV6 -eq 1 ]]; then
         GATEWAY6="${PREFIX6}${IID6}"
     fi
-
+    
     SUBNET_NET4="${GATEWAY4%.*}.0/24"
     [[ $IPV6 -eq 1 ]] && SUBNET_NET6="${PREFIX6}/64"
-
+    
 }
 
 prepare_wifi_interface() {
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         iw dev "${WIFI_IFACE}" set power_save off
     fi
-
+    
     if [[ $NO_VIRT -eq 0 ]]; then
     ## Will generate virtual wifi interface
-
+    
         # TODO move this to check_wifi_settings() ?
         if is_interface_wifi_connected "${WIFI_IFACE}"; then
             WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}' | sed 's/\.00*$//g')  # NOTE we assume integer currently, which can be right, or wrong  in the future
             WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel "${WIFI_IFACE_FREQ}")
-
+            
             echo "${WIFI_IFACE} already working in channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
-
+            
             if [[ $CHANNEL == default ]]; then
                 echo "Use wifi adapter current channel $WIFI_IFACE_CHANNEL as target channel"
                 CHANNEL=$WIFI_IFACE_CHANNEL
             fi
-
+            
             if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
                 echo "WARN: Wifi adapter already working in channel ${WIFI_IFACE_CHANNEL}, which is different than target channel $CHANNEL" >&2
             fi
@@ -1890,7 +1890,7 @@ prepare_wifi_interface() {
         if iw dev "${WIFI_IFACE}" interface add "${VWIFI_IFACE}" type __ap; then
             # Successfully created virtual wifi interface
             # if NM running, it will give the new virtual interface a random MAC. MAC will go back after setting NM unmanaged
-            sleep 2
+            sleep 2  
             echo "${VWIFI_IFACE} created"
         else
             VWIFI_IFACE=
@@ -1902,12 +1902,12 @@ prepare_wifi_interface() {
               die "Failed creating virtual WiFi interface. Maybe your WiFi adapter does not fully support virtual interfaces. Try again with '--no-virt'"
             fi
         fi
-
+        
         AP_IFACE=${VWIFI_IFACE}
     else # no virtual wifi interface, use wifi device interface itself
         AP_IFACE=${WIFI_IFACE}
     fi
-
+    
     if [[ $CHANNEL == default ]]; then
         echo "Channel not specified, use default"
         if [[ $FREQ_BAND == 2.4 ]]; then
@@ -1930,12 +1930,12 @@ decide_subnet_interface() {
 
 dealwith_mac() {
     local VMAC
-
-    if [[ -n "$NEW_MACADDR" ]] ; then  # user choose to set subnet mac
+    
+    if [[ -n "$NEW_MACADDR" ]] ; then  # user choose to set subnet mac 
 
         echo "Setting ${SUBNET_IFACE} new MAC address ${NEW_MACADDR} ..."
         set_interface_mac "${SUBNET_IFACE}" "${NEW_MACADDR}" || die "Failed setting new MAC address"
-
+        
     elif [[ $VWIFI_IFACE ]]; then # user didn't choose to set mac, but using virtual wifi interface
 
         VMAC=$(get_new_macaddr_according_to_existing "${WIFI_IFACE}")
@@ -1946,7 +1946,7 @@ dealwith_mac() {
     fi
 }
 
-write_hostapd_conf() {
+write_hostapd_conf() {  
     cat <<- EOF > "$CONFDIR/hostapd.conf"
 		beacon_int=100
 		ssid=${SSID}
@@ -2009,7 +2009,6 @@ write_hostapd_conf() {
     if [[ $REQUIREHE -eq 1 ]]; then
         echo "require_he=1" >> "$CONFDIR/hostapd.conf"
     fi
-
 
 
     if [[ -n "$VHT_CAPAB" ]]; then
@@ -2083,11 +2082,11 @@ write_dnsmasq_conf() {
     else
         NOBODY_GROUP="nogroup"
     fi
-
+    
     mkfifo "$CONFDIR/dnsmasq.log" || die "Failed creating pipe file for dnsmasq"
     chown nobody "$CONFDIR/dnsmasq.log" || die "Failed changing dnsmasq log file owner"
-    cat "$CONFDIR/dnsmasq.log" &
-
+    cat "$CONFDIR/dnsmasq.log" & 
+    
     cat <<- EOF > "$CONFDIR/dnsmasq.conf"
 		user=nobody
 		group=$NOBODY_GROUP
@@ -2105,7 +2104,7 @@ write_dnsmasq_conf() {
 	EOF
     # 'log-dhcp'(Extra logging for DHCP) shows too much logs.
     # if use '-d', 'log-facility' should = /dev/null
-    if [[ $SHARE_METHOD == "none" ]]; then
+    if [[ $SHARE_METHOD == "none" ]]; then    
         echo "no-resolv"  >> "$CONFDIR/dnsmasq.conf"
         echo "no-poll" >> "$CONFDIR/dnsmasq.conf"
     fi
@@ -2117,7 +2116,7 @@ write_dnsmasq_conf() {
         fi
         echo "dhcp-option-force=option:dns-server,${dns_offer}" >> "$CONFDIR/dnsmasq.conf"
     fi
-
+    
     if [[ ! "$dnsmasq_NO_DNS" -eq 0 ]]; then
         echo "port=0"  >> "$CONFDIR/dnsmasq.conf"
     fi
@@ -2132,7 +2131,7 @@ write_dnsmasq_conf() {
     if [[ ! "$SHOW_DNS_QUERY" -eq 0 ]]; then
         echo log-queries=extra >> "$CONFDIR/dnsmasq.conf"
     fi
-
+    
     if [[ $DNS ]]; then
         DNS_count=$(echo "$DNS" | awk -F, '{print NF}')
         for (( i=1;i<=DNS_count;i++ )); do
@@ -2140,7 +2139,7 @@ write_dnsmasq_conf() {
             [[ "$DNS_PORT" ]] && DNS_PORT_D="#$DNS_PORT"
             echo "server=${DNS_IP}${DNS_PORT_D}" >> "$CONFDIR/dnsmasq.conf"
         done
-
+        
         cat <<- EOF >> "$CONFDIR/dnsmasq.conf"
 			no-resolv
 			no-poll
@@ -2174,7 +2173,7 @@ run_wifi_ap_processes() {
         HAVEGED_WATCHDOG_PID=$!
         echo "$HAVEGED_WATCHDOG_PID" > "$CONFDIR/haveged_watchdog.pid"
         echo
-        echo "haveged_watchdog PID: $HAVEGED_WATCHDOG_PID"
+        echo "haveged_watchdog PID: $HAVEGED_WATCHDOG_PID" 
     fi
 
     # start access point
@@ -2184,14 +2183,14 @@ run_wifi_ap_processes() {
     if [ $? -eq 0 ]; then
         STDBUF_PATH=$STDBUF_PATH" -oL"
     fi
-    echo
+    echo 
     echo "Starting hostapd"
-
+    
     if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
         echo "Setting hostapd to AppArmor complain mode..."
         "$COMPLAIN_CMD" hostapd
     fi
-
+    
     # hostapd '-P' works only when use '-B' (run in background)
     $STDBUF_PATH hostapd $HOSTAPD_DEBUG_ARGS -P "$CONFDIR/hostapd.pid" "$CONFDIR/hostapd.conf"  &
     HOSTAPD_PID=$!
@@ -2206,17 +2205,17 @@ run_wifi_ap_processes() {
 }
 
 start_dnsmasq() {
-    echo
+    echo 
     echo "Starting dnsmasq"
-
+    
     if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
         echo "Setting dnsmasq to AppArmor complain mode..."
         "$COMPLAIN_CMD" dnsmasq
     fi
-
+    
     # Using '-d'(no daemon) dnsmasq will not turn into 'nobody'
     # '-x' works only when no '-d'
-    dnsmasq  -k -C "$CONFDIR/dnsmasq.conf" -x "$CONFDIR/dnsmasq.pid" -l "$CONFDIR/dnsmasq.leases" &
+    dnsmasq  -k -C "$CONFDIR/dnsmasq.conf" -x "$CONFDIR/dnsmasq.pid" -l "$CONFDIR/dnsmasq.leases" & 
     #####DNSMASQ_PID=$!         # only when with '-d'
     ######echo "dnsmasq PID: $DNSMASQ_PID"      # only when with '-d'
     i=0; while [[ ! -f "$CONFDIR/dnsmasq.pid" ]]; do
@@ -2225,7 +2224,7 @@ start_dnsmasq() {
         if [[ $i -gt 10 ]]; then die "Couldn't get dnsmasq PID" ; fi
     done
     DNSMASQ_PID="$(cat "$CONFDIR/dnsmasq.pid" )"
-    echo  "dnsmasq PID: $DNSMASQ_PID"
+    echo  "dnsmasq PID: $DNSMASQ_PID" 
     ######(wait $DNSMASQ_PID ; die "dnsmasq failed") &  # wait can't deal with non-child
     pid_watchdog "$DNSMASQ_PID" 9 "dnsmasq failed" &
     sleep 2
@@ -2240,7 +2239,7 @@ check_rfkill_unblock_wifi() {
 #=========== Above are functions ======================
 #=========== Executing begin ==============================
 
-# if empty option, show usage and exit
+# if empty option, show usage and exit 
 check_empty_option "$@"
 
 # TODO: are some global variables are still defined in those following code?
@@ -2254,12 +2253,12 @@ parse_user_options "$@"
 
 TMPDIR="$(decide_tmpdir)"
 
-# if user choose to deal with running instances, will output some info then exit after this
+# if user choose to deal with running instances, will output some info then exit after this 
 # NOTE above don't require root
-check_other_functions
+check_other_functions 
 # NOTE below require root
 
-# if user choose to daemonize, will start new background process and exit this
+# if user choose to daemonize, will start new background process and exit this 
 daemonizing_check
 
 # check if wifi will work on this system and user settings
@@ -2351,7 +2350,7 @@ else
     IP_VERs=("4" "6")
 fi
 
-disable_unwanted_forwarding
+disable_unwanted_forwarding 
 
 
 # bring subnet interface up
@@ -2375,36 +2374,36 @@ fi
 if [[ "$SHARE_METHOD" == "none" ]]; then
 
     echo "No Internet sharing"
-
+    
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-
+    
 elif [[ "$SHARE_METHOD" == "nat" ]]; then
     [[ "$INTERNET_IFACE" && "$dnsmasq_NO_DNS" -eq 0 ]] && echo -e "\nWARN: You specified Internet interface but this host is providing local DNS. In some unexpected case (eg. mistaken configurations), queries may leak to other interfaces, which you should be aware of.\n" >&2
-
+    
     start_nat
-
+    
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-
+    
     echo 1 > "/proc/sys/net/ipv4/ip_forward" || die "Failed enabling system ipv4 forwarding" # TODO maybe uneeded in '--no4' mode
-
+    
     if [[ $IPV6 -eq 1 ]]; then
         echo 1 > "/proc/sys/net/ipv6/conf/all/forwarding" || die "Failed enabling system ipv6 forwarding" # TODO if '-o' used, set only 2 interfaces' bits
     fi
-
+    
     # to enable clients to establish PPTP connections we must
     # load nf_nat_pptp module
     modprobe nf_nat_pptp > /dev/null 2>&1 && echo "Loaded kernel module nf_nat_pptp"
-
+    
 elif [[ "$SHARE_METHOD" == "redsocks" ]]; then
 
     if [[ $IPV6 -eq 1 ]]; then
         echo 1 > "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/forwarding" || die "Failed enabling $SUBNET_IFACE ipv6 forwarding" # to set NA router bit
     fi
-
+    
     [[ "$dnsmasq_NO_DNS" -eq 0 && ! $DNS ]] &&  echo -e "\nWARN: You are using in transparent proxy mode but this host is providing local DNS. In some unexpected case (eg. mistaken configurations), queries may leak to other interfaces, which you should be aware of.\n" >&2
 
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-
+    
     start_redsocks
 fi
 
@@ -2423,7 +2422,7 @@ echo ""
 is_firewalld_running && firewalld_add_tmpzone
 
 
-echo
+echo 
 echo "== Setting up completed, now linux-router should be working =="
 
 #============================================================

--- a/lnxrouter
+++ b/lnxrouter
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.8.0-unstable1
+VERSION=0.8.0-unstable2
 PROGNAME="$(basename "$0")"
 
 export LC_ALL=C
@@ -33,17 +33,17 @@ Options:
                             queries to other interfaces)
     -n                      Do not provide Internet
     --ban-priv              Disallow clients to access my private network
-    
+
     -g <ip>                 This host's IPv4 address in subnet (mask is /24)
                             (example: '192.168.5.1' or '5' shortly)
     -6                      Enable IPv6 (NAT)
     --no4                   Disable IPv4 Internet (not forwarding IPv4).
                             Usually used with '-6'
-                            
-    --p6 <prefix>           Set IPv6 LAN address prefix (length 64) 
-                            (example: 'fd00:0:0:5::' or '5' shortly) 
+
+    --p6 <prefix>           Set IPv6 LAN address prefix (length 64)
+                            (example: 'fd00:0:0:5::' or '5' shortly)
                             Using this enables '-6'
-                            
+
     --dns <ip>|<port>|<ip:port>
                             DNS server's upstream DNS.
                             Use ',' to seperate multiple servers
@@ -51,37 +51,37 @@ Options:
                             (Note IPv6 addresses need '[]' around)
     --no-dns                Do not serve DNS
     --no-dnsmasq            Disable dnsmasq server (DHCP, DNS, RA)
-    --catch-dns             Transparent DNS proxy, redirect packets(TCP/UDP) 
+    --catch-dns             Transparent DNS proxy, redirect packets(TCP/UDP)
                             whose destination port is 53 to this host
     --log-dns               Show DNS query log (dnsmasq)
     --dhcp-dns <IP1[,IP2]>|no
                             Set IPv4 DNS offered by DHCP (default: this host).
     --dhcp-dns6 <IP1[,IP2]>|no
-                            Set IPv6 DNS offered by DHCP (RA) 
+                            Set IPv6 DNS offered by DHCP (RA)
                             (default: this host)
                             (Note IPv6 addresses need '[]' around)
-                            Using both above two will enable '--no-dns' 
+                            Using both above two will enable '--no-dns'
     --hostname <name>       DNS server associate this name with this host.
                             Use '-' to read name from /etc/hostname
     -d                      DNS server will take into account /etc/hosts
-    -e <hosts_file>         DNS server will take into account additional 
+    -e <hosts_file>         DNS server will take into account additional
                             hosts file
     --dns-nocache           DNS server no cache
-    
+
     --mac <MAC>             Set MAC address
     --random-mac            Use random MAC address
- 
+
     --tp <port>             Transparent proxy,
                             redirect non-LAN TCP and UDP(not tested) traffic to
                             port. (usually used with '--dns')
-    
+
   WiFi hotspot options:
     --ap <wifi interface> <SSID>
                             Create WiFi access point
-    -p, --password <password>   
+    -p, --password <password>
                             WiFi password
     --qr                    Show WiFi QR code in terminal (need qrencode)
-    
+
     --hidden                Hide access point (not broadcast SSID)
     --no-virt               Do not create virtual interface
                             Using this you can't use same wlan interface
@@ -113,44 +113,44 @@ Options:
     --wifi5                 Enable IEEE 802.11ac (VHT)
     --req-vht               Require station VHT (Very High Thoughtput) mode
     --vht-capab <VHT caps>  VHT capabilities
-    
+
     --vht-ch-width <index>  Index of VHT channel width:
                                 0 for 20MHz or 40MHz (default)
                                 1 for 80MHz
                                 2 for 160MHz
-                                3 for 80+80MHz (Non-contigous 160MHz)    
-    --vht-seg0-ch <channel> Channel index of VHT center frequency for primary 
+                                3 for 80+80MHz (Non-contigous 160MHz)
+    --vht-seg0-ch <channel> Channel index of VHT center frequency for primary
                             segment. Use with '--vht-ch-width'
     --vht-seg1-ch <channel> Channel index of VHT center frequency for secondary
                             (second 80MHz) segment. Use with '--vht-ch-width 3'
-   
+
     WiFi 6 (802.11ax) configs:
     --wifi6                 Enable IEEE 802.11ax (HE)
     --req-he                Require station HE (High Efficiency) mode
-    
+
     --he-ch-width <index>   Index of HE channel width:
                                 0 for 20MHz or 40MHz (default)
                                 1 for 80MHz
                                 2 for 160MHz
-                                3 for 80+80MHz (Non-contigous 160MHz)    
+                                3 for 80+80MHz (Non-contigous 160MHz)
     --he-seg0-ch <channel>  Channel index of HE center frequency for primary
                             segment. Use with '--he-ch-width'
     --he-seg1-ch <channel>  Channel index of HE center frequency for secondary
                             (second 80MHz) segment. Use with '--he-ch-width 3'
- 
+
   Instance managing:
     --daemon                Run in background
     --keep-confdir          Don't delete the temporary config dir after exit
 
     -l, --list-running      Show running instances
-    --lc, --list-clients <id|interface>     
+    --lc, --list-clients <id|interface>
                             List clients of an instance. Or list neighbors of
                             an interface, even if it isn't handled by us.
                             (passive mode)
     --stop <id>             Stop a running instance
         For <id> you can use PID or subnet interface name.
         You can get them with '--list-running'
-                
+
 Examples:
     $PROGNAME -i eth1
     $PROGNAME --ap wlan0 MyAccessPoint -p MyPassPhrase
@@ -185,26 +185,26 @@ define_global_variables(){
     DNS_NOCACHE=
     CONN_IFACE=    # which interface user choose to use to create network
     INTERNET_IFACE= # which interface to get Internet from
-    THISHOSTNAME=   # this host's name the DNS tells clients 
+    THISHOSTNAME=   # this host's name the DNS tells clients
     TP_PORT=  # transparent proxy port
     DNS=  # upstream DNS
     MAC_USE_RANDOM=0
     NEW_MACADDR=
     DAEMONIZE=0
-    
+
     # script variables
     SUBNET_IFACE=  # which interface to create network
-    SHARE_METHOD=nat 
+    SHARE_METHOD=nat
     OLD_MACADDR=
     SUBNET_NET4=
     SUBNET_NET6=
-    
+
 
     ##### wifi hotspot
     # user options
     HIDDEN=0 # hidden wifi hotspot
     WIFI_IFACE=
-    CHANNEL=default 
+    CHANNEL=default
     HOTSPOT20=0 # For enabling Hotspot 2.0
     WPA_VERSION=2
     MAC_FILTER=0
@@ -232,7 +232,7 @@ define_global_variables(){
     USE_PSK=0
     ISOLATE_CLIENTS=0
     QR=0 # show wifi qr
-    
+
     # script variables
     PHY=
     VWIFI_IFACE=  # virtual wifi interface name, if created
@@ -240,7 +240,7 @@ define_global_variables(){
     AP_IFACE=     # can be VWIFI_IFACE or WIFI_IFACE
     USE_IWCONFIG=0  # some device can't use iw
     #######
-    
+
     #-- to deal with info of a running instance. then will exit
     LIST_RUNNING=0
     STOP_ID=
@@ -291,8 +291,8 @@ parse_user_options(){
                 SHARE_METHOD=redsocks
                 shift
                 ;;
-                
-                
+
+
             -g)
                 shift
                 GATEWAY4="$1"
@@ -321,7 +321,7 @@ parse_user_options(){
                 shift
                 MAC_USE_RANDOM=1
                 ;;
-                
+
             --dns)
                 shift
                 DNS="$1"
@@ -348,7 +348,7 @@ parse_user_options(){
             --catch-dns)
                 shift
                 CATCH_DNS=1
-                ;;    
+                ;;
             --log-dns)
                 shift
                 SHOW_DNS_QUERY=1
@@ -371,12 +371,12 @@ parse_user_options(){
                 shift
                 DNS_NOCACHE=1
                 ;;
-            
+
             --isolate-clients)
                 shift
                 ISOLATE_CLIENTS=1
                 ;;
-                
+
             --ap)
                 shift
                 WIFI_IFACE="$1"
@@ -393,8 +393,8 @@ parse_user_options(){
                 shift
                 QR=1
                 ;;
-                
-                
+
+
             --hidden)
                 shift
                 HIDDEN=1
@@ -580,7 +580,7 @@ sep_ip_port() {
     local PORT
     local INPUT
     INPUT="$1"
-    if (echo "$INPUT" | grep '\.' >/dev/null 2>&1) ;then  
+    if (echo "$INPUT" | grep '\.' >/dev/null 2>&1) ;then
         if (echo "$INPUT" | grep ':' >/dev/null 2>&1) ;then
             # ipv4 + port
             IP="$(echo "$INPUT" | cut -d: -f1)"
@@ -589,7 +589,7 @@ sep_ip_port() {
             # ipv4
             IP="$INPUT"
         fi
-    elif (echo "$INPUT" | grep '\]' >/dev/null 2>&1) ;then 
+    elif (echo "$INPUT" | grep '\]' >/dev/null 2>&1) ;then
         if (echo "$INPUT" | grep '\]\:' >/dev/null 2>&1) ;then
             # ipv6 + port
             IP="$(echo "$INPUT" | cut -d']' -f1 | cut -d'[' -f2)"
@@ -598,7 +598,7 @@ sep_ip_port() {
             # ipv6
             IP="$(echo "$INPUT" | cut -d']' -f1 | cut -d'[' -f2)"
         fi
-    else 
+    else
         # port
         IP='127.0.0.1'
         PORT="$INPUT"
@@ -745,35 +745,35 @@ get_interface_mac() {
 
 show_interface_pci_info() {  # pci id / model / virtual
     is_interface "$1" || return
-    
+
     local device_path
     local bus_id=""
     local device_type_and_bus_id="unknown"
     local driver=""
     local device_fullname=""
-    
+
     device_path="$(readlink -f /sys/class/net/$1)"
-    
+
     if [[ "$device_path" == "/sys/devices/pci"* ]]; then
         local pci_path
 
         pci_path=$device_path/../..
-        
+
         if [[ -d "$pci_path/driver" ]] ; then
             driver=$(readlink -f "$pci_path/driver" | sed 's/\//\n/g' | tail -n 1)
         fi
-        
+
         bus_id="$(echo "$device_path" | sed 's/\//\n/g' | tail -n 3 |sed -n 1p)"
         device_type_and_bus_id="PCI: $bus_id"
-        
+
         if which lspci >/dev/null 2>&1 ; then
             device_fullname="$( lspci -D -nn -s "$bus_id" | awk '{$1="" ; print $0}' )"
         fi
-        
+
     elif [[ "$device_path" == *"/virtual/"* ]]; then
         device_type_and_bus_id="virtual interface"
     fi
-    
+
     echo "$device_type_and_bus_id"
     [[ -n "$driver" ]] && echo "System-already-loaded driver: $driver"
     [[ -n "$device_fullname" ]] && echo "$device_fullname"
@@ -820,7 +820,7 @@ get_new_macaddr_according_to_existing() {
 }
 
 generate_random_mac() {
-    local r1 r2 r3 r4 r5 r6 
+    local r1 r2 r3 r4 r5 r6
     local RAND_MAC
     while :; do
         r1=$( printf "%02x" $(($RANDOM%256/4*4)) )
@@ -905,7 +905,7 @@ pid_watchdog() {
     local ERR_MSG="$3"
     local ST
     while true
-    do 
+    do
         if [[ -e "/proc/$PID" ]]; then
             ST="$(cat "/proc/$PID/status" | grep "^State:" | awk '{print $2}')"
             if [[ "$ST" != 'Z' ]]; then
@@ -915,18 +915,18 @@ pid_watchdog() {
         fi
         die "$ERR_MSG"
     done
-    
+
 }
 #========
 get_pid_by_dbus_name() {
     local DBUS_NAME="$1"
     local pid  r
-    
+
     which dbus-send >/dev/null 2>&1 || return 1
-    
+
     pid="$( dbus-send --system --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.GetConnectionUnixProcessID string:$DBUS_NAME  2>/dev/null | grep "   uint32 " | awk '{print $2}' )"
     r=$?
-    
+
     echo "$pid"
     return $r
 }
@@ -940,15 +940,15 @@ is_same_netns() {
 # only support NetworkManager >= 0.9.9
 is_nm_running() {
     NM_PID="$(get_pid_by_dbus_name "org.freedesktop.NetworkManager")"
-    
+
     [[ ! -n "$NM_PID" ]] && return 1 # not running
-    
+
     if (which nmcli >/dev/null 2>&1 ) && (nmcli -t -f RUNNING g 2>&1 | grep -E '^running$' >/dev/null 2>&1 ) ; then
         if is_same_netns "$NM_PID"; then
             return 0
         fi
     fi
-    
+
     NM_PID= # cancel value if treat as not running
     return 1  # not running
 }
@@ -989,9 +989,9 @@ nm_restore_manage() {
 #-------
 is_firewalld_running() {
     FIREWALLD_PID="$(get_pid_by_dbus_name "org.fedoraproject.FirewallD1")"
-    
+
     [[ ! -n "$FIREWALLD_PID" ]] && return 1 # not running
-    
+
     if (which firewall-cmd >/dev/null 2>&1 ) && [[ "$(firewall-cmd --state 2>&1)" == "running" ]] ; then
         if is_same_netns "$FIREWALLD_PID"; then
             echo "firewalld is running ($(firewall-cmd --version))"
@@ -1022,7 +1022,7 @@ CUSTOM_CHAINS_4_filter=
 CUSTOM_CHAINS_4_nat=
 CUSTOM_CHAINS_6_filter=
 CUSTOM_CHAINS_6_nat=
-iptb() 
+iptb()
 {
     local FoS=$1 # 4 | 6
     shift
@@ -1034,26 +1034,26 @@ iptb()
     shift
     local CH=$1 # chain
     shift
-    
+
     [[ "$IPV6" -ne 1 && "$FoS" == "6" ]] && return
-    
+
     local CMD_HEAD=""
     local MOUTH=""
     local NECK=""
     local HAND_UN_NC=0
     local TAIL=""
-    
+
     local FULL=""
     local ADD_TO_UNDO=1
-    
+
     local arr_name  w
-    
+
     for arr_name in CUSTOM_CHAINS_4_filter CUSTOM_CHAINS_4_nat CUSTOM_CHAINS_6_filter CUSTOM_CHAINS_6_nat
     do
         local arr_content
         eval arr_content=\"\${$arr_name}\"
         #echo $arr_content
-        
+
         for w in  $arr_content
         do
             if [[ "$arr_name" =~ "$FoS" && "$arr_name" =~ "$T" && "$w" == "$CH" ]]; then
@@ -1061,37 +1061,37 @@ iptb()
             fi
         done
     done
-    
+
 
     [[ "$FoS" == "4" ]] && CMD_HEAD="iptables -w "
     [[ "$FoS" == "6" ]] && CMD_HEAD="ip6tables -w "
-    
+
     [[ "$Vis" == 'v' ]] && MOUTH="-v"
-    
+
     NECK="-t ${T}"
-    
+
     if [[ "$ACT" == "N" ]]; then
         eval CUSTOM_CHAINS_${FoS}_${T}=\"\${CUSTOM_CHAINS_${FoS}_${T}} ${CH}\"
         HAND_UN_NC=1
     fi
-    
-    
-    
+
+
+
     [[ ! "$NETFILTER_XT_MATCH_COMMENT" == "0" ]] && TAIL="-m comment --comment lrt${$}${SUBNET_IFACE}"
-    
+
     if [[ "$ADD_TO_UNDO" -eq 1 ]]; then
         if [[ "$ACT" == "I" || "$ACT" == "A" ]]; then
-            echo "$CMD_HEAD $NECK -D ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables.sh 
+            echo "$CMD_HEAD $NECK -D ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables.sh
         fi
-        
+
         if [[ "$HAND_UN_NC" -eq 1 ]]; then
             echo "$CMD_HEAD $NECK -F ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables_2.sh
             echo "$CMD_HEAD $NECK -X ${CH} $@ $TAIL" >> $CONFDIR/undo_iptables_2.sh
         fi
     fi
-    
- 
-    
+
+
+
 
     FULL="$CMD_HEAD $MOUTH $NECK -${ACT} ${CH} $@ $TAIL"
     #echo $FULL
@@ -1109,40 +1109,40 @@ disable_unwanted_forwarding() {
                 ! -i "$INTERNET_IFACE"    -o "$SUBNET_IFACE" \
                 -j REJECT || die
         fi
-        
+
         if [[ "$SHARE_METHOD" == 'redsocks' || "$SHARE_METHOD" == 'none' \
             || ( "$iv" -eq "4" && "$NO4" -eq 1  ) ]];then
             iptb "$iv" n filter I FORWARD  -i "$SUBNET_IFACE"  -j REJECT || die
             iptb "$iv" n filter I FORWARD  -o "$SUBNET_IFACE"  -j REJECT || die
         fi
     done
-        
+
 }
 start_nat() {
     local SUBNET_NET
-    
+
     local iv
 
     echo
     echo "iptables: NAT "
-    
+
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" && ! $NO4 -eq 0 ]] && continue
-        
+
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
-        
+
         if [[ -n "$INTERNET_IFACE" ]]; then # only one Internet interface
             # masquerade subnet -> internet
             iptb "$iv" v nat I POSTROUTING -s "$SUBNET_NET"  ! -d "$SUBNET_NET" \
                 -o "$INTERNET_IFACE" \
                 -j MASQUERADE || die
-                
+
             # forward subnet -> internet
             iptb "$iv" v filter I FORWARD  -i "$SUBNET_IFACE"  -s "$SUBNET_NET" \
                 -o $INTERNET_IFACE \
                 -j ACCEPT || die
-            
+
             # forward any -> subnet
             iptb "$iv" v filter I FORWARD  -o "$SUBNET_IFACE"  -d "$SUBNET_NET"  \
                 -i "$INTERNET_IFACE" \
@@ -1152,32 +1152,32 @@ start_nat() {
             iptb "$iv" v nat I POSTROUTING -s "$SUBNET_NET"  ! -d "$SUBNET_NET" \
                 ! -o "$SUBNET_IFACE"  \
                 -j MASQUERADE || die
-                
+
             # forward subnet -> any
             iptb "$iv" v filter I FORWARD  -i "$SUBNET_IFACE"  -s "$SUBNET_NET"  \
                 -j ACCEPT || die
-                
+
             # forward any -> subnet
             iptb "$iv" v filter I FORWARD  -o "$SUBNET_IFACE"  -d "$SUBNET_NET" \
                 -j ACCEPT || die
         fi
-    done 
+    done
 }
 
 start_ban_lan() {
     local arr_nets_to_protect
     local ICMP_NAME
     local iv  s
-    
+
     echo
     echo "iptables: Disallow clients to access LAN"
-    
+
     for iv in "${IP_VERs[@]}"; do
         # ban forwarding for subnet
         iptb "$iv" n filter N lrt${$}${SUBNET_IFACE}-BLF || die
         # TODO: allow '--dhcp-dns(6)' address port 53, which can be something needed, e.g. a VPN's internal private IP
         if [[ "$iv" -eq "4" ]]; then
-            arr_nets_to_protect=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255") 
+            arr_nets_to_protect=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255")
             ICMP_NAME="icmp"
         elif [[ "$iv" -eq "6" ]]; then
             arr_nets_to_protect=("fc00::/7" "fe80::/10" "ff00::/8" "::1" "::/128" "::ffff:0:0/96" "::ffff:0:0:0/96")
@@ -1187,7 +1187,7 @@ start_ban_lan() {
             iptb "$iv" v filter I lrt${$}${SUBNET_IFACE}-BLF -d "$s" -j REJECT || die
         done
         iptb "$iv" n filter I FORWARD -i ${SUBNET_IFACE} -j lrt${$}${SUBNET_IFACE}-BLF || die
-        
+
         # ban input from subnet
         iptb "$iv" n filter N lrt${$}${SUBNET_IFACE}-BLI || die
         iptb "$iv" v filter I lrt${$}${SUBNET_IFACE}-BLI -i ${SUBNET_IFACE} ! -p "$ICMP_NAME" -j REJECT || die # ipv6 need icmp to function. TODO: maybe we can block some unneeded icmp to improve security
@@ -1202,14 +1202,14 @@ allow_dns_port() {
     local PROTs
     local iv  pt
 
-    
+
     echo
     echo "iptables: allow DNS"
-    
+
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" ]] && GATEWAY="$GATEWAY4"
         [[ "$iv" -eq "6" ]] && GATEWAY="$GATEWAY6"
-        
+
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
 
@@ -1218,7 +1218,7 @@ allow_dns_port() {
         for pt in "${PROTs[@]}"; do
             iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -d "$GATEWAY" -p "$pt" -m "$pt" --dport 53 -j ACCEPT || die
         done
-    done 
+    done
 }
 
 
@@ -1229,11 +1229,11 @@ start_catch_dns() {
 
     echo
     echo "iptables: redirect DNS queries to this host"
-    
+
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" ]] && GATEWAY="$GATEWAY4"
         [[ "$iv" -eq "6" ]] && GATEWAY="$GATEWAY6"
-   
+
         PROTs=("tcp" "udp")
         for pt in "${PROTs[@]}"; do
             iptb "$iv" v nat I PREROUTING -i "$SUBNET_IFACE" ! -d "$GATEWAY" -p "$pt" -m "$pt" --dport 53 -j REDIRECT --to-ports 53 || die
@@ -1243,9 +1243,9 @@ start_catch_dns() {
 
 
 allow_dhcp() {
-    echo 
+    echo
     echo "iptables: allow dhcp"
-    
+
     iptb 4 v filter I INPUT -i ${SUBNET_IFACE} -p udp -m udp --dport 67 -j ACCEPT || die
     iptb 6 v filter I INPUT -i ${SUBNET_IFACE} -p udp -m udp --dport 547 -j ACCEPT || die
 }
@@ -1255,25 +1255,25 @@ start_redsocks() {
     local SUBNET_NET
     local arr_nets_to_ignore
     local s iv
-    
+
     echo
     echo "iptables: transparent proxy non-LAN TCP and UDP(not tested) traffic to port ${TP_PORT}"
-    
+
     for iv in "${IP_VERs[@]}"; do
         [[ "$iv" -eq "4" && ! $NO4 -eq 0 ]] && continue
-        
+
         [[ "$iv" -eq "4" ]] && SUBNET_NET="$SUBNET_NET4"
         [[ "$iv" -eq "6" ]] && SUBNET_NET="$SUBNET_NET6"
-            
-            
+
+
         iptb "$iv" n nat N lrt${$}${SUBNET_IFACE}-TP || die
-        
+
         if [[ "$iv" -eq "4" ]]; then
             arr_nets_to_ignore=("0.0.0.0/8" "10.0.0.0/8" "100.64.0.0/10" "127.0.0.0/8" "169.254.0.0/16" "172.16.0.0/12" "192.168.0.0/16" "224.0.0.0/4" "255.255.255.255")
         elif [[ "$iv" -eq "6" ]];then
             arr_nets_to_ignore=("fc00::/7" "fe80::/10" "ff00::/8" "::1" "::")
         fi
-        
+
         for s in "${arr_nets_to_ignore[@]}"; do
             iptb "$iv" n nat A lrt${$}${SUBNET_IFACE}-TP -d "$s" -j RETURN || die
         done
@@ -1283,7 +1283,7 @@ start_redsocks() {
 
         iptb "$iv" v nat I PREROUTING -i "$SUBNET_IFACE" -s "$SUBNET_NET" -j lrt${$}${SUBNET_IFACE}-TP || die
 
-        
+
         iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -p tcp -m tcp --dport ${TP_PORT}  -j ACCEPT || die
         iptb "$iv" v filter I INPUT -i "$SUBNET_IFACE" -s "$SUBNET_NET" -p udp -m udp --dport ${TP_PORT}  -j ACCEPT || die
     done
@@ -1297,7 +1297,7 @@ backup_ipv6_bits() {
         "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/use_tempaddr"  \
         "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/addr_gen_mode" \
             "$CONFDIR/sys_6_conf_iface/" || die "Failed backing up interface ipv6 bits"
-            
+
     if [[ "$SHARE_METHOD" == 'redsocks' ]] ; then
         cp "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/forwarding" \
             "$CONFDIR/sys_6_conf_iface/" || die "Failed backking up interface ipv6 bits"
@@ -1322,45 +1322,45 @@ restore_ipv6_bits() {
 set_interface_mac() {
     local INTERFACE
     local MAC
-    
+
     INTERFACE=$1
     MAC=$2
-    
-    ip link set dev "${INTERFACE}" address "${MAC}" 
+
+    ip link set dev "${INTERFACE}" address "${MAC}"
 }
 
 backup_interface_status() {
     # virtual wifi interface will be destroyed, so no need to save status
-    
+
     # backup interface up or down status
     (ip link show "${SUBNET_IFACE}" |grep -q "state UP") && SUBNET_IFACE_ORIGINAL_UP_STATUS=1
-    
-    # save interface old mac 
-    #if [[ -n "$NEW_MACADDR" ]]; then 
+
+    # save interface old mac
+    #if [[ -n "$NEW_MACADDR" ]]; then
         OLD_MACADDR=$(get_interface_mac "$SUBNET_IFACE")
         #echo "Saved ${SUBNET_IFACE} old MAC address ${OLD_MACADDR} into RAM"
     #fi
-    
+
     backup_ipv6_bits
-    
+
     # TODO : ? backup ip and others???
-    
+
     # nm managing status is saved when nm_set_unmanaged()
 }
 restore_interface_status() {
     # virtual wifi interface will be destroyed, so no need to restore status
     # don't use [[ $VWIFI_IFACE ]] to judge, if creating virtual wifi failed, VWIFI_IFACE is empty
     [[ "$WIFI_IFACE" && "$NO_VIRT" -eq 0 ]] && return
-    
+
     restore_ipv6_bits
 
     if [[ -n "$OLD_MACADDR" && "$(get_interface_mac "$SUBNET_IFACE")" != "$OLD_MACADDR" ]] ; then
         echo "Restoring ${SUBNET_IFACE} to old MAC address ${OLD_MACADDR} ..."
         set_interface_mac "${SUBNET_IFACE}" "${OLD_MACADDR}" || echo "Failed restoring ${SUBNET_IFACE} to old MAC address ${OLD_MACADDR}" >&2
     fi
-    
+
     nm_restore_manage
-    
+
     [[ $SUBNET_IFACE_ORIGINAL_UP_STATUS -eq 1 ]] && ip link set up dev "${SUBNET_IFACE}" && echo "Restore ${SUBNET_IFACE} to link up"
 }
 #---------------------------------------
@@ -1373,7 +1373,7 @@ kill_processes() { # for this instance
         # a value in $x. so we need to check if the value is a file
         if [[ -f $x ]] &&  sleep 0.3  && [[ -f $x ]]; then
             pid=$(cat "$x")
-            pn=$( ps -p "$pid" -o comm= ) 
+            pn=$( ps -p "$pid" -o comm= )
             #echo "Killing $pid $pn ... "
             pkill -P "$pid"
             kill "$pid" 2>/dev/null && ( echo "Killed $(basename "$x") $pid $pn" && rm "$x" ) || echo "Failed to kill $(basename "$x") $pid $pn, it may have exited"
@@ -1385,27 +1385,27 @@ _cleanup() {
     local x
 
     ip addr flush "${SUBNET_IFACE}"
-    
+
     [[ ! "$KEEP_CONFDIR" -eq 1 ]] && rm -rf "$CONFDIR"
-    
+
     ip link set down dev "${SUBNET_IFACE}"
-    
+
     firewalld_del_tmpzone
-    
+
     if [[ $VWIFI_IFACE ]]; then # the subnet interface (virtual wifi interface) will be removed
         iw dev "${VWIFI_IFACE}" del
         dealloc_vface_name "$VWIFI_IFACE"
     fi
-    
+
     restore_interface_status
-    
+
     if ! has_running_instance; then
         echo "Exiting: This is the only running instance"
         # kill common processes
         for x in $COMMON_CONFDIR/*.pid; do
             [[ -f $x ]] && kill -9 $(cat "$x") && rm "$x"
         done
-        
+
         rm -d "$COMMON_CONFDIR/vfaces"
         rm -d "$COMMON_CONFDIR"
         rm -d "$TMPDIR"
@@ -1416,7 +1416,7 @@ _cleanup() {
 
 clean_iptables() {
     [[ -f $CONFDIR/undo_iptables.sh ]] && bash $CONFDIR/undo_iptables.sh
-    
+
     [[ -f $CONFDIR/undo_iptables_2.sh ]] && bash $CONFDIR/undo_iptables_2.sh
 }
 
@@ -1430,11 +1430,11 @@ cleanup() {
     echo "Undoing iptables changes .."
     clean_iptables > /dev/null
     _cleanup 2> /dev/null
-    
+
     #pgid=$(ps opgid= $$ |awk '{print $1}' )
     #echo "Killing PGID $pgid ..."
     #kill -15 -$pgid
-    #sleep 1 
+    #sleep 1
     echo "Cleaning up done"
     #kill -9 -$pgid
 }
@@ -1526,7 +1526,7 @@ print_clients_from_leases() {  # MAC|IP|HOST|lease
     local FILEC
     local line
     local LEASEstr LEASEstamp
-    
+
     FILEC="$(cat "$LEASE_FILE" | grep -v -E "^duid\b" | sed -r '/^\s*$/d' )"
 
     # TODO: duid is somewhat related to ipv6. I don't know about it. Not sure excluding it miss some info or not
@@ -1537,31 +1537,31 @@ print_clients_from_leases() {  # MAC|IP|HOST|lease
         MAC="$(echo "$line" | awk '{print $2}')"
         IP="$(echo "$line" | awk '{print $3}'  | sed 's/\[//g' | sed 's/\]//g')"
         HOST="$(echo "$line" | awk '{print $4}' | sed 's/*/?/g' | sed 's/|/_/g' | sed 's/ /_/g' )"
-        
+
         if [[ -n "$MAC" ]]; then
             LEASEstr="$(date -d @${LEASEstamp} +%m-%d_%X)"
-            
+
             echo "$MAC|$IP|$HOST|lease_$LEASEstr"
         fi
     done
-    
+
 }
-print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS 
+print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS
     local IFACE=$1
-    
+
     local line
-    
+
     ip n | grep -E "\bdev $IFACE\b" | sed 's/ /|/g' | while read -r line
     do
         local MAC IP STATUS
-        
+
         IP="$(echo "$line" | awk -F'|' '{print $1}')"
-        
+
         if [[ "$(echo "$line" | awk -F'|' '{print $4}')" == "lladdr" ]]; then # has mac
             # if has mac, $4="lladdr" and $5=macaddress and $6+=status
             MAC="$(echo "$line" | awk -F'|' '{print $5}')"
             STATUS="$(echo "$line" | awk -F'|' '$1="";$2="";$3="";$4="";$5="";{print}' | awk '{$1=$1;print}'| sed 's/ /,/g')"
-        else # no mac 
+        else # no mac
             # if no mac, $4="" and $5+=status
             MAC="?"
             STATUS="$(echo "$line" | awk -F'|' '$1="";$2="";$3="";$4="";{print}' | awk '{$1=$1;print}' | sed 's/ /,/g')"
@@ -1571,7 +1571,7 @@ print_interface_neighbors_via_iproute() {  # MAC|IP|_|STATUS
         fi
     done
 }
-print_interface_neighbors_via_iw() {  # MAC|_|_|signal  
+print_interface_neighbors_via_iw() {  # MAC|_|_|signal
     local IFACE=$1
     local MAC SIGNAL
     iw dev "$IFACE" station dump | awk '($1 ~ /Station$/) {print $2}' | while read -r MAC
@@ -1586,14 +1586,14 @@ print_interface_neighbors_via_iw() {  # MAC|_|_|signal
 list_clients() { # passive mode. (use 'arp-scan' or 'netdiscover' if want active mode)
     local IFACE pid
     local CONFDIR
-    
+
     local output=""
     # If number (PID) is given, get the associated wifi iface
     if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
         pid="$1"
         IFACE=$(get_subn_iface_from_pid "$pid")
         if [[ -z "$IFACE" ]] ; then
-            echo "'$pid' is not the pid of a running $PROGNAME instance." >&2 
+            echo "'$pid' is not the pid of a running $PROGNAME instance." >&2
             exit 1
         fi
     else # non-number given
@@ -1612,14 +1612,14 @@ list_clients() { # passive mode. (use 'arp-scan' or 'netdiscover' if want active
     fi
     output="$(echo "$output" ; print_interface_neighbors_via_iw "$IFACE") "
     output="$(echo "$output" ; print_interface_neighbors_via_iproute "$IFACE")"
-    
+
     output="$(echo "$output" | sort -k 1 -k 2 -t '|' | uniq | sed -r '/^\s*$/d')"
 
     echo "$IFACE ($(get_interface_mac "$IFACE")) neighbors:"
-    
+
     local fmt="%-19s%-41s%-20s%s" # string length: MAC 17, ipv4 15, ipv6 39, hostname ?
     printf "$fmt\n"  "MAC" "IP" "HOSTNAME" "INFO"
-    
+
     local line
     echo "$output"| while read -r line
     do
@@ -1732,14 +1732,14 @@ check_wifi_settings() {
         echo "WARN: Can't use 'iw' to operate interfce '$WIFI_IFACE', trying 'iwconfig' (not as good as 'iw') ..." >&2
         USE_IWCONFIG=1
     fi
-    
+
     if [[ $USE_IWCONFIG -eq 1 ]]; then
         if ! (which iwconfig > /dev/null 2>&1 && iwconfig "$WIFI_IFACE" > /dev/null 2>&1); then
             echo "ERROR: Can't use 'iwconfig' to operate interfce '$WIFI_IFACE'" >&2
             exit 1
         fi
     fi
-    
+
     if [[ $FREQ_BAND != 2.4 && $FREQ_BAND != 5 ]]; then
         echo "ERROR: Invalid frequency band" >&2
         exit 1
@@ -1778,7 +1778,7 @@ check_wifi_settings() {
             DRIVER=rtl871xdrv
         fi
     fi
-    
+
     if [[ ${#SSID} -lt 1 || ${#SSID} -gt 32 ]]; then
         echo "ERROR: Invalid SSID length ${#SSID} (expected 1..32)" >&2
         exit 1
@@ -1854,32 +1854,32 @@ decide_ip_addresses() {
     if [[ $IPV6 -eq 1 ]]; then
         GATEWAY6="${PREFIX6}${IID6}"
     fi
-    
+
     SUBNET_NET4="${GATEWAY4%.*}.0/24"
     [[ $IPV6 -eq 1 ]] && SUBNET_NET6="${PREFIX6}/64"
-    
+
 }
 
 prepare_wifi_interface() {
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         iw dev "${WIFI_IFACE}" set power_save off
     fi
-    
+
     if [[ $NO_VIRT -eq 0 ]]; then
     ## Will generate virtual wifi interface
-    
+
         # TODO move this to check_wifi_settings() ?
         if is_interface_wifi_connected "${WIFI_IFACE}"; then
             WIFI_IFACE_FREQ=$(iw dev "${WIFI_IFACE}" link | grep -i freq | awk '{print $2}' | sed 's/\.00*$//g')  # NOTE we assume integer currently, which can be right, or wrong  in the future
             WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel "${WIFI_IFACE_FREQ}")
-            
+
             echo "${WIFI_IFACE} already working in channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
-            
+
             if [[ $CHANNEL == default ]]; then
                 echo "Use wifi adapter current channel $WIFI_IFACE_CHANNEL as target channel"
                 CHANNEL=$WIFI_IFACE_CHANNEL
             fi
-            
+
             if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
                 echo "WARN: Wifi adapter already working in channel ${WIFI_IFACE_CHANNEL}, which is different than target channel $CHANNEL" >&2
             fi
@@ -1890,7 +1890,7 @@ prepare_wifi_interface() {
         if iw dev "${WIFI_IFACE}" interface add "${VWIFI_IFACE}" type __ap; then
             # Successfully created virtual wifi interface
             # if NM running, it will give the new virtual interface a random MAC. MAC will go back after setting NM unmanaged
-            sleep 2  
+            sleep 2
             echo "${VWIFI_IFACE} created"
         else
             VWIFI_IFACE=
@@ -1902,12 +1902,12 @@ prepare_wifi_interface() {
               die "Failed creating virtual WiFi interface. Maybe your WiFi adapter does not fully support virtual interfaces. Try again with '--no-virt'"
             fi
         fi
-        
+
         AP_IFACE=${VWIFI_IFACE}
     else # no virtual wifi interface, use wifi device interface itself
         AP_IFACE=${WIFI_IFACE}
     fi
-    
+
     if [[ $CHANNEL == default ]]; then
         echo "Channel not specified, use default"
         if [[ $FREQ_BAND == 2.4 ]]; then
@@ -1930,12 +1930,12 @@ decide_subnet_interface() {
 
 dealwith_mac() {
     local VMAC
-    
-    if [[ -n "$NEW_MACADDR" ]] ; then  # user choose to set subnet mac 
+
+    if [[ -n "$NEW_MACADDR" ]] ; then  # user choose to set subnet mac
 
         echo "Setting ${SUBNET_IFACE} new MAC address ${NEW_MACADDR} ..."
         set_interface_mac "${SUBNET_IFACE}" "${NEW_MACADDR}" || die "Failed setting new MAC address"
-        
+
     elif [[ $VWIFI_IFACE ]]; then # user didn't choose to set mac, but using virtual wifi interface
 
         VMAC=$(get_new_macaddr_according_to_existing "${WIFI_IFACE}")
@@ -1946,7 +1946,7 @@ dealwith_mac() {
     fi
 }
 
-write_hostapd_conf() {  
+write_hostapd_conf() {
     cat <<- EOF > "$CONFDIR/hostapd.conf"
 		beacon_int=100
 		ssid=${SSID}
@@ -2009,6 +2009,7 @@ write_hostapd_conf() {
     if [[ $REQUIREHE -eq 1 ]]; then
         echo "require_he=1" >> "$CONFDIR/hostapd.conf"
     fi
+
 
 
     if [[ -n "$VHT_CAPAB" ]]; then
@@ -2082,11 +2083,11 @@ write_dnsmasq_conf() {
     else
         NOBODY_GROUP="nogroup"
     fi
-    
+
     mkfifo "$CONFDIR/dnsmasq.log" || die "Failed creating pipe file for dnsmasq"
     chown nobody "$CONFDIR/dnsmasq.log" || die "Failed changing dnsmasq log file owner"
-    cat "$CONFDIR/dnsmasq.log" & 
-    
+    cat "$CONFDIR/dnsmasq.log" &
+
     cat <<- EOF > "$CONFDIR/dnsmasq.conf"
 		user=nobody
 		group=$NOBODY_GROUP
@@ -2104,7 +2105,7 @@ write_dnsmasq_conf() {
 	EOF
     # 'log-dhcp'(Extra logging for DHCP) shows too much logs.
     # if use '-d', 'log-facility' should = /dev/null
-    if [[ $SHARE_METHOD == "none" ]]; then    
+    if [[ $SHARE_METHOD == "none" ]]; then
         echo "no-resolv"  >> "$CONFDIR/dnsmasq.conf"
         echo "no-poll" >> "$CONFDIR/dnsmasq.conf"
     fi
@@ -2116,7 +2117,7 @@ write_dnsmasq_conf() {
         fi
         echo "dhcp-option-force=option:dns-server,${dns_offer}" >> "$CONFDIR/dnsmasq.conf"
     fi
-    
+
     if [[ ! "$dnsmasq_NO_DNS" -eq 0 ]]; then
         echo "port=0"  >> "$CONFDIR/dnsmasq.conf"
     fi
@@ -2131,7 +2132,7 @@ write_dnsmasq_conf() {
     if [[ ! "$SHOW_DNS_QUERY" -eq 0 ]]; then
         echo log-queries=extra >> "$CONFDIR/dnsmasq.conf"
     fi
-    
+
     if [[ $DNS ]]; then
         DNS_count=$(echo "$DNS" | awk -F, '{print NF}')
         for (( i=1;i<=DNS_count;i++ )); do
@@ -2139,7 +2140,7 @@ write_dnsmasq_conf() {
             [[ "$DNS_PORT" ]] && DNS_PORT_D="#$DNS_PORT"
             echo "server=${DNS_IP}${DNS_PORT_D}" >> "$CONFDIR/dnsmasq.conf"
         done
-        
+
         cat <<- EOF >> "$CONFDIR/dnsmasq.conf"
 			no-resolv
 			no-poll
@@ -2173,7 +2174,7 @@ run_wifi_ap_processes() {
         HAVEGED_WATCHDOG_PID=$!
         echo "$HAVEGED_WATCHDOG_PID" > "$CONFDIR/haveged_watchdog.pid"
         echo
-        echo "haveged_watchdog PID: $HAVEGED_WATCHDOG_PID" 
+        echo "haveged_watchdog PID: $HAVEGED_WATCHDOG_PID"
     fi
 
     # start access point
@@ -2183,14 +2184,14 @@ run_wifi_ap_processes() {
     if [ $? -eq 0 ]; then
         STDBUF_PATH=$STDBUF_PATH" -oL"
     fi
-    echo 
+    echo
     echo "Starting hostapd"
-    
+
     if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
         echo "Setting hostapd to AppArmor complain mode..."
         "$COMPLAIN_CMD" hostapd
     fi
-    
+
     # hostapd '-P' works only when use '-B' (run in background)
     $STDBUF_PATH hostapd $HOSTAPD_DEBUG_ARGS -P "$CONFDIR/hostapd.pid" "$CONFDIR/hostapd.conf"  &
     HOSTAPD_PID=$!
@@ -2205,17 +2206,17 @@ run_wifi_ap_processes() {
 }
 
 start_dnsmasq() {
-    echo 
+    echo
     echo "Starting dnsmasq"
-    
+
     if COMPLAIN_CMD="$(command -v aa-complain || command -v complain)"; then
         echo "Setting dnsmasq to AppArmor complain mode..."
         "$COMPLAIN_CMD" dnsmasq
     fi
-    
+
     # Using '-d'(no daemon) dnsmasq will not turn into 'nobody'
     # '-x' works only when no '-d'
-    dnsmasq  -k -C "$CONFDIR/dnsmasq.conf" -x "$CONFDIR/dnsmasq.pid" -l "$CONFDIR/dnsmasq.leases" & 
+    dnsmasq  -k -C "$CONFDIR/dnsmasq.conf" -x "$CONFDIR/dnsmasq.pid" -l "$CONFDIR/dnsmasq.leases" &
     #####DNSMASQ_PID=$!         # only when with '-d'
     ######echo "dnsmasq PID: $DNSMASQ_PID"      # only when with '-d'
     i=0; while [[ ! -f "$CONFDIR/dnsmasq.pid" ]]; do
@@ -2224,7 +2225,7 @@ start_dnsmasq() {
         if [[ $i -gt 10 ]]; then die "Couldn't get dnsmasq PID" ; fi
     done
     DNSMASQ_PID="$(cat "$CONFDIR/dnsmasq.pid" )"
-    echo  "dnsmasq PID: $DNSMASQ_PID" 
+    echo  "dnsmasq PID: $DNSMASQ_PID"
     ######(wait $DNSMASQ_PID ; die "dnsmasq failed") &  # wait can't deal with non-child
     pid_watchdog "$DNSMASQ_PID" 9 "dnsmasq failed" &
     sleep 2
@@ -2239,7 +2240,7 @@ check_rfkill_unblock_wifi() {
 #=========== Above are functions ======================
 #=========== Executing begin ==============================
 
-# if empty option, show usage and exit 
+# if empty option, show usage and exit
 check_empty_option "$@"
 
 # TODO: are some global variables are still defined in those following code?
@@ -2253,12 +2254,12 @@ parse_user_options "$@"
 
 TMPDIR="$(decide_tmpdir)"
 
-# if user choose to deal with running instances, will output some info then exit after this 
+# if user choose to deal with running instances, will output some info then exit after this
 # NOTE above don't require root
-check_other_functions 
+check_other_functions
 # NOTE below require root
 
-# if user choose to daemonize, will start new background process and exit this 
+# if user choose to daemonize, will start new background process and exit this
 daemonizing_check
 
 # check if wifi will work on this system and user settings
@@ -2350,7 +2351,7 @@ else
     IP_VERs=("4" "6")
 fi
 
-disable_unwanted_forwarding 
+disable_unwanted_forwarding
 
 
 # bring subnet interface up
@@ -2374,36 +2375,36 @@ fi
 if [[ "$SHARE_METHOD" == "none" ]]; then
 
     echo "No Internet sharing"
-    
+
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-    
+
 elif [[ "$SHARE_METHOD" == "nat" ]]; then
     [[ "$INTERNET_IFACE" && "$dnsmasq_NO_DNS" -eq 0 ]] && echo -e "\nWARN: You specified Internet interface but this host is providing local DNS. In some unexpected case (eg. mistaken configurations), queries may leak to other interfaces, which you should be aware of.\n" >&2
-    
+
     start_nat
-    
+
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-    
+
     echo 1 > "/proc/sys/net/ipv4/ip_forward" || die "Failed enabling system ipv4 forwarding" # TODO maybe uneeded in '--no4' mode
-    
+
     if [[ $IPV6 -eq 1 ]]; then
         echo 1 > "/proc/sys/net/ipv6/conf/all/forwarding" || die "Failed enabling system ipv6 forwarding" # TODO if '-o' used, set only 2 interfaces' bits
     fi
-    
+
     # to enable clients to establish PPTP connections we must
     # load nf_nat_pptp module
     modprobe nf_nat_pptp > /dev/null 2>&1 && echo "Loaded kernel module nf_nat_pptp"
-    
+
 elif [[ "$SHARE_METHOD" == "redsocks" ]]; then
 
     if [[ $IPV6 -eq 1 ]]; then
         echo 1 > "/proc/sys/net/ipv6/conf/$SUBNET_IFACE/forwarding" || die "Failed enabling $SUBNET_IFACE ipv6 forwarding" # to set NA router bit
     fi
-    
+
     [[ "$dnsmasq_NO_DNS" -eq 0 && ! $DNS ]] &&  echo -e "\nWARN: You are using in transparent proxy mode but this host is providing local DNS. In some unexpected case (eg. mistaken configurations), queries may leak to other interfaces, which you should be aware of.\n" >&2
 
     [[ "$BANLAN" -eq 1 ]] && start_ban_lan
-    
+
     start_redsocks
 fi
 
@@ -2422,7 +2423,7 @@ echo ""
 is_firewalld_running && firewalld_add_tmpzone
 
 
-echo 
+echo
 echo "== Setting up completed, now linux-router should be working =="
 
 #============================================================

--- a/lnxrouter
+++ b/lnxrouter
@@ -2087,8 +2087,8 @@ run_wifi_ap_processes() {
     echo 
     echo "Starting hostapd"
     
-    if which complain > /dev/null 2>&1; then
-        complain hostapd
+    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
+        $COMPLAIN_CMD hostapd
     fi
     
     # hostapd '-P' works only when use '-B' (run in background)
@@ -2108,10 +2108,10 @@ start_dnsmasq() {
     echo 
     echo "Starting dnsmasq"
     
-    if which complain > /dev/null 2>&1; then
+    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
         # openSUSE's apparmor does not allow dnsmasq to read files.
         # remove restriction.
-        complain dnsmasq
+        $COMPLAIN_CMD dnsmasq
     fi
     
     # Using '-d'(no daemon) dnsmasq will not turn into 'nobody'


### PR DESCRIPTION
Adds partial wifi 6 support.

<details> <summary> Connection Test Screenshot: </summary>

Tested on an RTL8852BE WifFi 6 PCIe Card for hotspot and a Samsung S24+ Phone as host

Command used for testing:
`
sudo /usr/local/bin/lnxrouter --dns 127.0.0.1 -d --ap $interface rock5boi -p asiudfbla --no-virt -c 149 --freq-band 5 -w "1+2" --no-virt --hs20 --wifi4 --req-ht --ht-capab "[HT40+][HT40-][LDPC][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC1][MAX-AMSDU-7935][DSSS_CCK-40][SMPS-STATIC]" --wifi5 --req-vht --vht-capab "[MAX-MPDU-11454][RXLDPC][SHORT-GI-80][TX-STBC-2BY1][SU-BEAMFORMEE][HTC-VHT]" --vht-ch-width 1 --vht-seg0-ch 155 --country BZ --no-dnsmasq -g 10.9.8.1 --ieee80211ax --he-ch-width 1 --he-seg0-ch 155
`

<img src="https://github.com/user-attachments/assets/d55354ad-096e-4bf1-9fa8-2983365fa2f3" height=682 width=350>

</details>

### New arguments:
1. `--wifi6`             Enable IEEE 802.11ax (HE)
2. `--req-he`          Require station HE (High Efficiency) mode
3. `--he-ch-width <index>`   Index of HE channel width:
                                `0` for 20MHz or 40MHz (default)
                                `1` for 80MHz
                                `2` for 160MHz
                                `3` for 80+80MHz (Non-contigous 160MHz)    
4. `--he-seg0-ch <channel>`  Channel index of HE center frequency for primary
                            segment. Use with '--he-ch-width'
5. `--he-seg1-ch <channel>` Channel index of HE center frequency for secondary
                            (second 80MHz) segment. Use with '--he-ch-width 3'

Above arguments operate similar to their `wifi5` counterparts.

### Notes:

* Wifi 6 requires hostapd built with wifi 6 support, with "CONFIG_IEEE80211AX=y" in buildconf
* Wifi 6 hotspot only works with wifi 6 cards only
* Requires additional testing
* Need to add more HE capabilities to the script.
* Wifi 6 is backward compatible with wifi 5 clients only if `--req-he` is NOT used.

<details> <summary> Error when trying to connect with a WiFi 5 client to a WiFi 6 Hotspot WITH `--req-he` </summary>

Red box shows the error when a wifi 5 client tries to connect when `--req-he` is used. Green box shows a successful connection to a wifi 6 client

![Screenshot_20240921_171254](https://github.com/user-attachments/assets/47c07256-9252-45b3-9d6d-6ee8cbbb4287)

</details>


Tasks:

- [x] add wmm 1 if ax is enabled as well
- [x] add 80211ax and require he
- [ ] add he (mu, su) beamformer and su beamformee options
- [x] fix wifi 6e devices' channel detection
