### PR TITLE
Fix a bug with complian command

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -2087,8 +2087,8 @@ run_wifi_ap_processes() {
     echo 
     echo "Starting hostapd"
     
-    if which complain > /dev/null 2>&1; then
-        complain hostapd
+    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
+        $COMPLAIN_CMD hostapd
     fi
     
     # hostapd '-P' works only when use '-B' (run in background)
@@ -2108,10 +2108,10 @@ start_dnsmasq() {
     echo 
     echo "Starting dnsmasq"
     
-    if which complain > /dev/null 2>&1; then
+    if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
         # openSUSE's apparmor does not allow dnsmasq to read files.
         # remove restriction.
-        complain dnsmasq
+        $COMPLAIN_CMD dnsmasq
     fi
     
     # Using '-d'(no daemon) dnsmasq will not turn into 'nobody'


### PR DESCRIPTION
added support for aa-complian. The issue was already fixed in linux-wifi-hotspot project.

https://github.com/lakinduakash/linux-wifi-hotspot/pull/314

---------------------
Issue: complain was not found on my system and the script could not be executed. Below is the error output.

Starting dnsmasq

dnsmasq: cannot read /dev/shm/lnxrouter_tmp/lnxrouter.wlp0s20f0u7.conf.U5zWYP/dnsmasq.conf: Permission denied Error occured

ERROR: Couldn't get dnsmasq PID

Error occured

Doing cleanup.. 
Killed haveged_watchdog.pid 216223 lnxrouter