### PR TITLE
Add WPA3 SAE support

### DIFF
--- a/lnxrouter
+++ b/lnxrouter
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.8.1
+VERSION=0.8.2-unstable1
 PROGNAME="$(basename "$0")"
 
 export LC_ALL=C

--- a/lnxrouter
+++ b/lnxrouter
@@ -92,8 +92,8 @@ Options:
                             (example: US)
     --freq-band <GHz>       Set frequency band: 2.4 or 5 (default: 2.4)
     --driver                Choose your WiFi adapter driver (default: nl80211)
-    -w <WPA version>        '2' for WPA2, '1' for WPA, '1+2' for both
-                            (default: 2)
+    --enalbe-wpa1           Enable WPA 1 (LEGACY)
+    -w <WPA version>        '2' for WPA2, '3' for WPA3, '2+3' for both, '0' to disable both (Default=2)
     --psk                   Use 64 hex digits pre-shared-key instead of
                             passphrase
     --mac-filter            Enable WiFi hotspot MAC address filtering
@@ -213,7 +213,9 @@ define_global_variables(){
     WIFI_IFACE=
     CHANNEL=default
     HOTSPOT20=0 # For enabling Hotspot 2.0
-    WPA_VERSION=2
+    WPA1_ENABLE=0 # For enabling WPA1, marked as legacy
+    WPA2_ENABLE=1 # Enable WPA2 PSK-Personal
+    WPA3_ENABLE=0 # Enable WPA3 SAE
     MAC_FILTER=0
     MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
     DRIVER=nl80211
@@ -428,10 +430,31 @@ parse_user_options(){
                 shift
                 HOTSPOT20=1
                 ;;
+            --enable-wpa1)
+                shift
+                WPA1_ENABLE=1
+                ;;
             -w)
                 shift
-                WPA_VERSION="$1"
-                [[ "$WPA_VERSION" == "2+1" ]] && WPA_VERSION=1+2
+                # WPA_VERSION="$1"
+                # [[ "$WPA_VERSION" == "2+3" ]] && WPA_VERSION=2+3
+                case "$1" in
+                    "2")
+                        WPA2_ENABLE=1
+                        ;;
+                    "3")
+                        WPA2_ENABLE=0
+                        WPA3_ENABLE=1
+                        ;;
+                    "2+3"|"3+2")
+                        WPA2_ENABLE=1
+                        WPA3_ENABLE=1
+                        ;;
+                    "0")
+                        WPA2_ENABLE=0
+                        WPA3_ENABLE=0
+                        ;;
+                esac
                 shift
                 ;;
             --sta-timeout)
@@ -1840,7 +1863,7 @@ check_wifi_settings() {
     fi
 
     if [[ $(get_adapter_kernel_module "${WIFI_IFACE}") =~ ^rtl[0-9].*$ ]]; then
-        if [[ $WPA_VERSION == '1' || $WPA_VERSION == '1+2' ]]; then
+        if [[ $WPA1_ENABLE == '1' ]]; then
             echo "WARN: Realtek drivers usually have problems with WPA1, WPA2 is recommended" >&2
         fi
         echo "WARN: If AP doesn't work, read https://github.com/oblique/create_ap/blob/master/howto/realtek.md" >&2
@@ -2025,7 +2048,22 @@ write_hostapd_conf() {
     fi
 
     if [[ -n "$PASSPHRASE" ]]; then
-        [[ "$WPA_VERSION" == "1+2" ]] && WPA_VERSION=3
+        # [[ "$WPA_VERSION" == "1+2" ]] && WPA_VERSION=3
+        WPA_VERSION=0
+        WPA_KEYMGMT=""
+        if [[ $WPA1_ENABLE -eq 1 ]]; then
+            WPA_VERSION=$(($WPA_VERSION + 1))
+        fi
+        if [[ $WPA2_ENABLE -eq 1 || $WPA3_ENABLE -eq 1 ]]; then
+            WPA_VERSION=$(($WPA_VERSION + 2))
+        fi
+        if [[ $WPA1_ENABLE -eq 1 || $WPA2_ENABLE -eq 1 ]]; then
+            WPA_KEYMGMT+="WPA-PSK"
+        fi
+        if [[ $WPA3_ENABLE -eq 1 ]]; then
+            [[ ! -z "$WPA_KEYMGMT" ]] && WPA_KEYMGMT+=" "
+            WPA_KEYMGMT+="SAE"
+        fi
         if [[ $USE_PSK -eq 0 ]]; then
             WPA_KEY_TYPE=passphrase
         else
@@ -2034,7 +2072,7 @@ write_hostapd_conf() {
         cat <<- EOF >> "$CONFDIR/hostapd.conf"
 			wpa=${WPA_VERSION}
 			wpa_${WPA_KEY_TYPE}=${PASSPHRASE}
-			wpa_key_mgmt=WPA-PSK
+			wpa_key_mgmt=${WPA_KEYMGMT}
 			wpa_pairwise=CCMP
 			rsn_pairwise=CCMP
 		EOF

--- a/lnxrouter
+++ b/lnxrouter
@@ -92,10 +92,11 @@ Options:
                             (example: US)
     --freq-band <GHz>       Set frequency band: 2.4 or 5 (default: 2.4)
     --driver                Choose your WiFi adapter driver (default: nl80211)
-    --enalbe-wpa1           Enable WPA 1 (LEGACY)
-    -w <WPA version>        '2' for WPA2, '3' for WPA3, '2+3' for both, '0' to disable both (Default=2)
-    --psk                   Use 64 hex digits pre-shared-key instead of
-                            passphrase
+    -w <WPA version>        WPA version indicator, can be '2', '3', '1', '3+2',
+                            '3+2+1', '2+1'. Requires '-p'. (default: '2')
+                            (Note WPA1 is legacy and unsafe)
+    --psk                   Use 64 hex digits pre-shared-key. Value of '-p'
+                            should be hex string instead of password
     --mac-filter            Enable WiFi hotspot MAC address filtering
     --mac-filter-accept     Location of WiFi hotspot MAC address filter list
                             (defaults to /etc/hostapd/hostapd.accept)
@@ -213,7 +214,7 @@ define_global_variables(){
     WIFI_IFACE=
     CHANNEL=default
     HOTSPOT20=0 # For enabling Hotspot 2.0
-    WPA1_ENABLE=0 # For enabling WPA1, marked as legacy
+    WPA1_ENABLE=0 # Enable legacy unsafe WPA1
     WPA2_ENABLE=1 # Enable WPA2 PSK-Personal
     WPA3_ENABLE=0 # Enable WPA3 SAE
     MAC_FILTER=0
@@ -430,30 +431,30 @@ parse_user_options(){
                 shift
                 HOTSPOT20=1
                 ;;
-            --enable-wpa1)
-                shift
-                WPA1_ENABLE=1
-                ;;
             -w)
                 shift
-                # WPA_VERSION="$1"
-                # [[ "$WPA_VERSION" == "2+3" ]] && WPA_VERSION=2+3
                 case "$1" in
-                    "2")
-                        WPA2_ENABLE=1
-                        ;;
                     "3")
-                        WPA2_ENABLE=0
-                        WPA3_ENABLE=1
+                        WPA1_ENABLE=0; WPA2_ENABLE=0; WPA3_ENABLE=1
                         ;;
-                    "2+3"|"3+2")
-                        WPA2_ENABLE=1
-                        WPA3_ENABLE=1
+                    "2")
+                        WPA1_ENABLE=0; WPA2_ENABLE=1; WPA3_ENABLE=0
                         ;;
-                    "0")
-                        WPA2_ENABLE=0
-                        WPA3_ENABLE=0
+                    "1")
+                        WPA1_ENABLE=1; WPA2_ENABLE=0; WPA3_ENABLE=0
                         ;;
+                    "3+2")
+                        WPA1_ENABLE=0; WPA2_ENABLE=1; WPA3_ENABLE=1
+                        ;;
+                    "2+1"|"1+2") # '1+2' is for compatibility to old script.
+                        WPA1_ENABLE=1; WPA2_ENABLE=1; WPA3_ENABLE=0
+                        ;;
+                    "3+2+1")
+                        WPA1_ENABLE=1; WPA2_ENABLE=1; WPA3_ENABLE=1
+                        ;;
+                    *)
+                        echo "Invalid -w value" >&2
+                        exit 1
                 esac
                 shift
                 ;;
@@ -1864,7 +1865,7 @@ check_wifi_settings() {
 
     if [[ $(get_adapter_kernel_module "${WIFI_IFACE}") =~ ^rtl[0-9].*$ ]]; then
         if [[ $WPA1_ENABLE == '1' ]]; then
-            echo "WARN: Realtek drivers usually have problems with WPA1, WPA2 is recommended" >&2
+            echo "WARN: Realtek drivers usually have problems with legacy WPA1" >&2
         fi
         echo "WARN: If AP doesn't work, read https://github.com/oblique/create_ap/blob/master/howto/realtek.md" >&2
     fi
@@ -2015,6 +2016,10 @@ dealwith_mac() {
 }
 
 write_hostapd_conf() {
+    local WPA_VERSION
+    local WPA_KEYMGMT
+    local WPA_KEY_TYPE
+
     cat <<- EOF > "$CONFDIR/hostapd.conf"
 		beacon_int=100
 		ssid=${SSID}
@@ -2048,9 +2053,8 @@ write_hostapd_conf() {
     fi
 
     if [[ -n "$PASSPHRASE" ]]; then
-        # [[ "$WPA_VERSION" == "1+2" ]] && WPA_VERSION=3
-        WPA_VERSION=0
-        WPA_KEYMGMT=""
+        WPA_VERSION=0    # 1 means wpa1. 2 means wpa2. 3 means wpa2+1
+        WPA_KEYMGMT=""   # WPA-PSK means wpa2 or wpa1. SAE means wpa3
         if [[ $WPA1_ENABLE -eq 1 ]]; then
             WPA_VERSION=$(($WPA_VERSION + 1))
         fi


### PR DESCRIPTION
Fixes #87. Adds support for WPA3 with SAE authentication. Refactored the arguments to handle WPA versions:
- Moved WPA1 to separate legacy arg.
- Merged WPA2 and 3 into `-w` arg.

Test Environment: Raspberry Pi 5B, EDUP EP-AX1672 with MT-7921 AXE Chip, hostapd compiled with `CONFIG_SAE=y` and `CONFIG_SAE_PK=y`

<details>

<summary> Tests </summary>

|arg option|screenshot|
|-|-|
|WPA 1+2+3 <br>`--enable-wpa1 -w "2+3"`|<img src="https://github.com/user-attachments/assets/b342cff3-d3a5-4e5c-8e90-9678b2b198a4" width=250/>|
|WPA 1+2 <br> `--enable-wpa1 -w "2"` | <img src="https://github.com/user-attachments/assets/a9b442c5-bb70-4065-a341-3e258469d9dd" alt="" width=250/>|
|WPA 2+3 <br> `-w "2+3"` | <img src="https://github.com/user-attachments/assets/001144e2-9c0a-499e-80d0-362d34aa837a" alt="" width=250/>|
|WPA 1+3 <br> `--enable-wpa1 -w "3"`<br> Auto enables WPA2 based on logic | <img src="https://github.com/user-attachments/assets/8adef560-f77c-446f-9d93-7a72a80750b1" alt="" width=250/>|
|WPA 3 <br> `-w "3"` | <img src="https://github.com/user-attachments/assets/b880a6a1-cd01-400d-a396-d69bb22aba5f" alt="" width=250/>|
|WPA 2 <br> `-w "2"` | <img src="https://github.com/user-attachments/assets/f1e91269-ea51-4806-93be-454fe7aee095" alt="" width=250/>|
|WPA 1 <br> `--enable-wpa1 -w "0"` | hostapd crashes |

</details>

Needs testing before merge.

References:
https://incolumitas.com/2019/02/22/running-a-WPA3-access-point-with-hostapd-SAE-Dragonfly/
https://github.com/vanhoefm/hostap-wpa3/tree/master