### PR TITLE
Add 'which' to the list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ I'm currently not packaging for any distro. If you do, open a PR and add the lin
 ### Dependencies
 
 - bash
+- which
 - procps or procps-ng
 - iproute2
 - dnsmasq


### PR DESCRIPTION
Script can't create access point if "which" package isn't installed causing this issue:
https://github.com/garywill/linux-router/issues/77#issue-2303653477